### PR TITLE
Fix link to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ rioxarray README
 
 rasterio xarray extension.
 
-Documentation: https://corteva.github.io/rioxarray.
+Documentation: https://corteva.github.io/rioxarray/html/index.html.
 
 
 .. image:: https://badges.gitter.im/rioxarray/community.svg


### PR DESCRIPTION
The current link results in a 404.

The new link is based on [the link to Geocube's documentation](https://github.com/corteva/geocube/blob/master/README.rst) (which works).