### PR TITLE
use input raster profile to write output raster profile & preserve None nodata if opened with xarray.open_rasterio

### DIFF
--- a/sphinx/history.rst
+++ b/sphinx/history.rst
@@ -7,6 +7,8 @@ History
 - Updated writing encoding for FutureWarning (issue #18)
 - Use input raster profile for defaults to write output raster profile if opened with `xarray.open_rasterio` (issue #19)
 - Preserve None nodata if opened with `xarray.open_rasterio` (issue #20)
+- Added `drop` argument for `clip()` (issue #25)
+- Fix order of `CRS` for reprojecting geometries in `clip()` (pull #24)
 
 0.0.5
 -----

--- a/sphinx/history.rst
+++ b/sphinx/history.rst
@@ -5,6 +5,8 @@ History
 -----
 - Add support for scalar coordinates in reproject (issue #15)
 - Updated writing encoding for FutureWarning (issue #18)
+- Use input raster profile for defaults to write output raster profile if opened with `xarray.open_rasterio` (issue #19)
+- Preserve None nodata if opened with `xarray.open_rasterio` (issue #20)
 
 0.0.5
 -----


### PR DESCRIPTION
 - [x] Closes #19 & #20
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API