### PR TITLE
fixed setting nodata in _add_attrs_proj

### DIFF
--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -137,7 +137,7 @@ def _add_attrs_proj(new_data_array, src_data_array):
     new_attrs = _generate_attrs(
         src_data_array,
         new_data_array.rio.transform(recalc=True),
-        new_data_array.rio.nodata,
+        None,
     )
     # remove fill value if it already exists in the encoding
     # this is for data arrays pulling the encoding from a

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -135,9 +135,7 @@ def _add_attrs_proj(new_data_array, src_data_array):
     """Make sure attributes and projection correct"""
     # make sure attributes preserved
     new_attrs = _generate_attrs(
-        src_data_array,
-        new_data_array.rio.transform(recalc=True),
-        None,
+        src_data_array, new_data_array.rio.transform(recalc=True), None
     )
     # remove fill value if it already exists in the encoding
     # this is for data arrays pulling the encoding from a

--- a/sphinx/history.rst
+++ b/sphinx/history.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.0.8
+-----
+ - Fix setting nodata in _add_attrs_proj (pull #30) 
+
 0.0.7
 -----
 - Add option to do an inverted clip (pull #29) 

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -324,6 +324,8 @@ def test_clip_geojson__no_drop(invert, expected_sum):
         assert clipped.rio.crs == xdi.rio.crs
         assert clipped.shape == xdi.shape
         assert clipped.sum().item() == expected_sum
+        assert clipped.rio.nodata == 0.0
+        assert clipped.rio.nodata == xdi.rio.nodata
 
         # test dataset
         clipped_ds = xdi.to_dataset(name="test_data").rio.clip(
@@ -332,6 +334,7 @@ def test_clip_geojson__no_drop(invert, expected_sum):
         assert clipped_ds.rio.crs == xdi.rio.crs
         assert clipped_ds.test_data.shape == xdi.shape
         assert clipped_ds.test_data.sum().item() == expected_sum
+        assert clipped_ds.test_data.rio.nodata == xdi.rio.nodata
 
 
 def test_transform_bounds():


### PR DESCRIPTION
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API


The problem with the original method is that there was no `nodata` value there yet. So, it would default to `False`. Then, when attempting to get the nodata value, it would return None even when there was a valid nodata value.