### PR TITLE
Use xarray.open_rasterio for rioxarray.open_rasterio with xarray<0.12.3

### DIFF
--- a/rioxarray/__init__.py
+++ b/rioxarray/__init__.py
@@ -6,5 +6,10 @@ __author__ = """rioxarray Contributors"""
 __email__ = "alansnow21@gmail.com"
 
 import rioxarray.rioxarray  # noqa
-from rioxarray._io import open_rasterio  # noqa
+
+try:
+    # This requires xarray >= 0.12.3
+    from rioxarray._io import open_rasterio  # noqa
+except ImportError:
+    from xarray import open_rasterio  # noqa
 from rioxarray._version import __version__  # noqa

--- a/sphinx/history.rst
+++ b/sphinx/history.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.0.12
+------
+ - Use `xarray.open_rasterio()` for `rioxarray.open_rasterio()` with xarray<0.12.3 (pull #40)
+
 0.0.11
 ------
 - Added `open_kwargs` to pass into `rasterio.open()` when using `rioxarray.open_rasterio()` (pull #48)


### PR DESCRIPTION
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API