### PR TITLE
write to raster using windowed writing & add isel_window method

### DIFF
--- a/sphinx/examples/convert_to_raster.ipynb
+++ b/sphinx/examples/convert_to_raster.ipynb
@@ -67,6 +67,7 @@
        "\u001b[0;34m\u001b[0m    \u001b[0mdriver\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'GTiff'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mdtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0mtags\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mwindowed\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m    \u001b[0;34m**\u001b[0m\u001b[0mprofile_kwargs\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
        "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
@@ -83,6 +84,9 @@
        "    The data type to write the raster to. Default is the datasets dtype.\n",
        "tags: dict, optional\n",
        "    A dictionary of tags to write to the raster.\n",
+       "windowed: bool, optional\n",
+       "    If True, it will write using the windows of the output raster.\n",
+       "    Default is False.\n",
        "**profile_kwargs\n",
        "    Additional keyword arguments to pass into writing the raster. The\n",
        "    nodata, transform, crs, count, width, and height attributes\n",
@@ -105,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rds.green.rio.to_raster(\"green_band.tif\", tiled=True, compress=\"LZMA\")"
+    "rds.green.rio.to_raster(\"green_band.tif\", tiled=True, compress=\"LZMA\", windowed=True)"
    ]
   },
   {
@@ -116,57 +120,10 @@
     {
      "data": {
       "text/plain": [
-       "<xarray.DataArray 'green' (time: 2, y: 10, x: 10)>\n",
-       "array([[[ 7.920639, 66.150832, 30.096116, 30.437197, 57.794734, 11.538647,\n",
-       "         14.426782, 35.593171, 53.784858,  0.449093],\n",
-       "        [23.804111, 67.910347, 18.694533, 30.41474 , 68.117674, 44.906057,\n",
-       "         62.311842, 37.485047, 57.134336,  7.52572 ],\n",
-       "        [36.653481, 39.596833, 61.07603 , 56.883093, 29.635613, 64.114699,\n",
-       "         42.341689, 54.724789, 31.872344, 11.282554],\n",
-       "        [32.502176, 28.090549, 58.398927, 41.224019, 34.804777, 32.184565,\n",
-       "         59.392327,  9.155824, 52.967172, 67.409236],\n",
-       "        [18.79468 ,  8.543429, 35.834698,  3.596245, 30.252802, 41.549499,\n",
-       "         23.060248,  7.267762, 27.374099,  0.684024],\n",
-       "        [ 9.93227 , 44.509446, 22.01927 , 28.514121, 36.715233, 15.03939 ,\n",
-       "          2.43399 ,  0.636075, 34.43023 , 37.024545],\n",
-       "        [28.874823,  1.514255, 34.210822, 10.49793 , 54.025491, 64.294026,\n",
-       "         36.212813, 17.766628, 45.295952, 10.349576],\n",
-       "        [58.961924, 47.334638, 64.844646, 37.634131,  7.815025, 35.139303,\n",
-       "         18.501505, 35.01185 , 27.761908, 13.240655],\n",
-       "        [49.544668, 57.716538, 27.389778, 11.604377, 24.826367, 15.449456,\n",
-       "         26.482386, 42.855739, 10.4958  , 59.267182],\n",
-       "        [37.094093, 43.294246, 33.240747, 16.85513 , 54.705119, 14.633291,\n",
-       "         35.138742, 50.101683, 57.495953, 52.795405]],\n",
-       "\n",
-       "       [[26.137058, 16.448086,  4.503539, 33.351036, 20.32524 , 63.369743,\n",
-       "         11.531512, 38.629561, 59.821441, 11.547508],\n",
-       "        [ 6.438471, 28.948907,  9.949052, 23.234921, 65.539507,  9.822554,\n",
-       "         55.754023, 51.590388, 57.047098,  4.929671],\n",
-       "        [32.360472, 17.939979, 52.889505, 69.181176, 39.2923  , 56.442225,\n",
-       "          5.699603, 21.092554,  8.93472 , 23.810367],\n",
-       "        [ 3.715695, 30.653733, 44.540496, 48.578544, 24.032477, 30.339109,\n",
-       "         37.376636, 58.787274, 49.308994, 59.510765],\n",
-       "        [37.991912, 50.023013, 63.711135, 26.546118, 60.561058, 36.098302,\n",
-       "         10.725673, 40.51609 , 47.479255, 42.710909],\n",
-       "        [15.32887 , 15.878984, 30.914778, 25.902812,  3.815428, 35.530366,\n",
-       "         48.426293, 44.280075,  4.468083, 18.00032 ],\n",
-       "        [58.286993, 20.397714, 63.124   , 69.117495,  1.32436 , 29.024715,\n",
-       "         31.601531, 34.307982,  7.990292, 36.159696],\n",
-       "        [34.674335, 62.344993,  5.714717,  2.161448, 66.714977, 52.443751,\n",
-       "         12.791859, 63.707491, 13.697063,  9.394474],\n",
-       "        [16.766346, 26.260123, 40.68158 , 18.695085, 64.812126, 23.151592,\n",
-       "         50.597642, 61.308205, 31.517123, 23.469797],\n",
-       "        [44.670989, 17.533084, 39.034907, 32.676726, 53.275139, 48.731172,\n",
-       "         12.958856, 21.760335, 27.292202, 18.409063]]])\n",
-       "Coordinates:\n",
-       "    spatial_ref  int64 ...\n",
-       "  * x            (x) float64 4.663e+05 4.663e+05 ... 4.663e+05 4.663e+05\n",
-       "  * time         (time) datetime64[ns] 2016-12-19T10:27:29.687763 2016-12-29T12:52:42.347451\n",
-       "  * y            (y) float64 8.085e+06 8.085e+06 ... 8.085e+06 8.085e+06\n",
-       "Attributes:\n",
-       "    units:         DN\n",
-       "    nodata:        0.0\n",
-       "    grid_mapping:  spatial_ref"
+       "((2, 10, 10),\n",
+       " CRS.from_epsg(32722),\n",
+       " nan,\n",
+       " (466266.0, 8084670.0, 466296.0, 8084700.0))"
       ]
      },
      "execution_count": 5,
@@ -175,7 +132,7 @@
     }
    ],
    "source": [
-    "rds.green"
+    "rds.green.shape, rds.green.rio.crs, rds.green.rio.nodata, rds.green.rio.bounds()"
    ]
   },
   {
@@ -187,7 +144,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"compress\": \"lzma\", \"count\": 2, \"crs\": \"EPSG:32722\", \"descriptions\": [null, null], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"lnglat\": [-51.317326412269495, -17.322997474192462], \"mask_flags\": [[\"nodata\"], [\"nodata\"]], \"nodata\": NaN, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": false, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
+      "{\"blockxsize\": 256, \"blockysize\": 256, \"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"compress\": \"lzma\", \"count\": 2, \"crs\": \"EPSG:32722\", \"descriptions\": [null, null], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"lnglat\": [-51.31732641226951, -17.322997474192466], \"mask_flags\": [[\"nodata\"], [\"nodata\"]], \"nodata\": NaN, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": true, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
      ]
     }
    ],
@@ -213,7 +170,7 @@
     {
      "data": {
       "text/plain": [
-       "(OrderedDict(), None, None)"
+       "(OrderedDict(), CRS.from_epsg(32722), None)"
       ]
      },
      "execution_count": 7,
@@ -244,7 +201,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"count\": 2, \"crs\": null, \"descriptions\": [null, null], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"mask_flags\": [[\"all_valid\"], [\"all_valid\"]], \"nodata\": null, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": false, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
+      "{\"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"count\": 2, \"crs\": \"EPSG:32722\", \"descriptions\": [null, null], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"lnglat\": [-51.31732641226951, -17.322997474192466], \"mask_flags\": [[\"all_valid\"], [\"all_valid\"]], \"nodata\": null, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": false, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
      ]
     }
    ],
@@ -297,7 +254,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"count\": 2, \"crs\": \"EPSG:32722\", \"descriptions\": [null, null], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"lnglat\": [-51.317326412269495, -17.322997474192462], \"mask_flags\": [[\"nodata\"], [\"nodata\"]], \"nodata\": 0.0, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": false, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
+      "{\"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"count\": 2, \"crs\": \"EPSG:32722\", \"descriptions\": [null, null], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"lnglat\": [-51.31732641226951, -17.322997474192466], \"mask_flags\": [[\"nodata\"], [\"nodata\"]], \"nodata\": 0.0, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": false, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
      ]
     }
    ],

--- a/sphinx/history.rst
+++ b/sphinx/history.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+0.0.14
+------
+- Add `windowed` kwarg to `rio.to_raster()` to write to raster using windowed writing (pull #54)
+- Added add `rio.isel_window()` to allow selection using a rasterio.windows.Window (pull #54)
+
 0.0.13
 ------
 - Improve CRS searching for xarray.Dataset & use default grid mapping name (pull #51)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #22 (start of #9)
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

The thing that I am on the fence about is if we want to make windowed writing the default or the previous behavior the default. The windowed writing can be more memory efficient, but may not be as fast reading the entire chunk into memory. There are different scenarios. So, maybe add a `windowed=True` kwarg to turn on/off this behavior.

Side note: since the block sizes of the destination raster are created with rasterio, it should be constant across all bands, so that isn't something to worry about.