### PR TITLE
Add boolean keyword trans_recalc to  to_raster() to turn transform re…

### DIFF
--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -1100,6 +1100,7 @@ class RasterArray(XRasterBase):
         dtype=None,
         tags=None,
         windowed=False,
+        recalc_transform=True,
         **profile_kwargs,
     ):
         """
@@ -1165,7 +1166,7 @@ class RasterArray(XRasterBase):
             count=count,
             dtype=dtype,
             crs=self.crs,
-            transform=self.transform(recalc=True),
+            transform=self.transform(recalc=recalc_transform),
             nodata=(
                 self.encoded_nodata if self.encoded_nodata is not None else self.nodata
             ),

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -728,13 +728,13 @@ def test_geographic_resample_integer(request):
         _assert_xarrays_equal(mds_interp, mdc)
 
 
-@pytest.mark.parametrize("windowed", [True, False])
-@pytest.fixture(params=[xarray.open_dataarray, rioxarray.open_rasterio])
-def test_to_raster(request, windowed, tmpdir):
+@pytest.mark.parametrize("windowed, recalc_transform", [(True, True), (False, False)])
+@pytest.fixture(params=[xarray.open_dataarray, rioxarray.open_rasterio]) 
+def test_to_raster(request, windowed, recalc_transform, tmpdir): 
     tmp_raster = tmpdir.join("modis_raster.tif")
     test_tags = {"test": "1"}
     with request.param(os.path.join(TEST_INPUT_DATA_DIR, "MODIS_ARRAY.nc")) as mda:
-        mda.rio.to_raster(str(tmp_raster), windowed=windowed, tags=test_tags)
+        mda.rio.to_raster(str(tmp_raster), windowed=windowed, recalc_transform=recalc_transform, tags=test_tags)
         xds = mda.copy()
 
     with rasterio.open(str(tmp_raster)) as rds:

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -729,12 +729,17 @@ def test_geographic_resample_integer(request):
 
 
 @pytest.mark.parametrize("windowed, recalc_transform", [(True, True), (False, False)])
-@pytest.fixture(params=[xarray.open_dataarray, rioxarray.open_rasterio]) 
-def test_to_raster(request, windowed, recalc_transform, tmpdir): 
+@pytest.fixture(params=[xarray.open_dataarray, rioxarray.open_rasterio])
+def test_to_raster(request, windowed, recalc_transform, tmpdir):
     tmp_raster = tmpdir.join("modis_raster.tif")
     test_tags = {"test": "1"}
     with request.param(os.path.join(TEST_INPUT_DATA_DIR, "MODIS_ARRAY.nc")) as mda:
-        mda.rio.to_raster(str(tmp_raster), windowed=windowed, recalc_transform=recalc_transform, tags=test_tags)
+        mda.rio.to_raster(
+            str(tmp_raster),
+            windowed=windowed,
+            recalc_transform=recalc_transform,
+            tags=test_tags,
+        )
         xds = mda.copy()
 
     with rasterio.open(str(tmp_raster)) as rds:


### PR DESCRIPTION
…calculation on/off

Add a keyword that would allow user to turn off the recalculation of the transform in the to_raster() function. Currently, the transform is always recalculated.

Proposed change is the addition of the recalc_transform keyword below:
def to_raster(
…
recalc_transform = True
…)

and

with rasterio.open(
....
transform=self.transform(recalc= recalc_transform)
…)

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #55
 - [x] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API