### PR TITLE
remove NC_GLOBAL# prefix for attributes in dataset

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -208,12 +208,14 @@ def _parse_envi(meta):
     return parsed_meta
 
 
-def _parse_tags(tags):
+def _parse_tags(tags, dataset_tags=False):
     def parsevec(s):
         return np.fromstring(s.strip("{}"), dtype="float", sep=",")
 
     parsed_tags = {}
     for key, value in tags.items():
+        # NC_GLOBAL is appended to tags with netcdf driver and is not really needed
+        key = key.split("NC_GLOBAL#")[-1] if dataset_tags else key
         if value.startswith("{") and value.endswith("}"):
             new_val = parsevec(value)
             value = new_val if len(new_val) else value
@@ -361,7 +363,7 @@ def _load_subdatasets(
     """
     Load in rasterio subdatasets
     """
-    base_tags = _parse_tags(riods.tags())
+    base_tags = _parse_tags(riods.tags(), dataset_tags=True)
     dim_groups = {}
     subdataset_filter = None
     if any((group, variable)):

--- a/sphinx/examples/convert_to_raster.ipynb
+++ b/sphinx/examples/convert_to_raster.ipynb
@@ -42,7 +42,7 @@
        "Data variables:\n",
        "    green        (band, y, x) float64 ...\n",
        "Attributes:\n",
-       "    NC_GLOBAL#coordinates:  spatial_ref</pre>"
+       "    coordinates:  spatial_ref</pre>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -55,7 +55,7 @@
        "Data variables:\n",
        "    green        (band, y, x) float64 ...\n",
        "Attributes:\n",
-       "    NC_GLOBAL#coordinates:  spatial_ref"
+       "    coordinates:  spatial_ref"
       ]
      },
      "execution_count": 2,

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -925,3 +925,10 @@ def test_notgeoreferenced_warning():
     with create_tmp_geotiff(transform_args=None) as (tmp_file, expected):
         with pytest.warns(NotGeoreferencedWarning):
             rioxarray.open_rasterio(tmp_file)
+
+
+def test_ncglobal_attr_filter():
+    with rioxarray.open_rasterio(
+        os.path.join(TEST_INPUT_DATA_DIR, "PLANET_SCOPE_3D.nc")
+    ) as rds:
+        assert rds.attrs == {'coordinates': 'spatial_ref'}

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -931,4 +931,4 @@ def test_ncglobal_attr_filter():
     with rioxarray.open_rasterio(
         os.path.join(TEST_INPUT_DATA_DIR, "PLANET_SCOPE_3D.nc")
     ) as rds:
-        assert rds.attrs == {'coordinates': 'spatial_ref'}
+        assert rds.attrs == {"coordinates": "spatial_ref"}


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #71
 - [x] Tests added
 - [ ] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Makes attribute reading consistent with `xarray,open_dataset`