### PR TITLE
 Add support for writing scales & offsets to raster; Don't write standard raster metadata to raster tags

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+0.0.19
+-------
+- Add support for writing scales & offsets to raster (pull #79)
+- Don't write standard raster metadata to raster tags (issue #78)
+
 0.0.18
 ------
 - Fixed windowed writing to require tiled output raster (pull #66)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #78
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API