### PR TITLE
BUG: ensure band_key is list when iterating over bands for mask and scale

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.0.20
+------
+- BUG: ensure band_key is list when iterating over bands for mask and scale (pull #87)
+
 0.0.19
 -------
 - Add support for writing scales & offsets to raster (pull #79)

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -146,7 +146,6 @@ class RasterioArrayWrapper(BackendArray):
         from rasterio.vrt import WarpedVRT
 
         band_key, window, squeeze_axis, np_inds = self._get_indexer(key)
-
         if not band_key or any(start == stop for (start, stop) in window):
             # no need to do IO
             shape = (len(band_key),) + tuple(stop - start for (start, stop) in window)
@@ -160,7 +159,7 @@ class RasterioArrayWrapper(BackendArray):
                 if self.masked:
                     out = np.ma.filled(out.astype(self.dtype), np.nan)
                 if self.mask_and_scale:
-                    for band in band_key:
+                    for band in np.atleast_1d(band_key):
                         band_iii = band - 1
                         out[band_iii] = (
                             out[band_iii] * riods.scales[band_iii]

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -146,6 +146,7 @@ class RasterioArrayWrapper(BackendArray):
         from rasterio.vrt import WarpedVRT
 
         band_key, window, squeeze_axis, np_inds = self._get_indexer(key)
+
         if not band_key or any(start == stop for (start, stop) in window):
             # no need to do IO
             shape = (len(band_key),) + tuple(stop - start for (start, stop) in window)


### PR DESCRIPTION
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Have only been able to replicate when calling `.plot()`:
```
~/scripts/rioxarray/rioxarray/_io.py in _getitem(self, key)
    161                     out = np.ma.filled(out.astype(self.dtype), np.nan)
    162                 if self.mask_and_scale:
--> 163                     for band in band_key:
    164                         band_iii = band - 1
    165                         out[band_iii] = (

TypeError: 'int' object is not iterable
```