### PR TITLE
ENH: Added to_raster method for Datasets

### DIFF
--- a/docs/examples/convert_to_raster.ipynb
+++ b/docs/examples/convert_to_raster.ipynb
@@ -7,10 +7,15 @@
     "# Example - Convert dataset to raster (GeoTiff)\n",
     "\n",
     "Often, it is desirable to take a variable (band) out of your dataset and export it to a raster.\n",
-    "This is possible with the [rio.to_raster()](../rioxarray.rst#rioxarray.rioxarray.RasterArray.to_raster) method. It does most of the work for you so you don't\n",
+    "This is possible with the `rio.to_raster()`method. It does most of the work for you so you don't\n",
     "have to.\n",
     "\n",
-    "Note: The [rio.to_raster()](../rioxarray.rst#rioxarray.rioxarray.RasterArray.to_raster) method only works on a 2-dimensional or 3-dimensional `xarray.DataArray`"
+    "Note: The `rio.to_raster()` method only works on a 2-dimensional or 3-dimensional `xarray.DataArray` or a 2-dimensional `xarray.Dataset`.\n",
+    "\n",
+    "API Reference:\n",
+    "\n",
+    "- DataArray: [rio.to_raster()](../rioxarray.rst#rioxarray.rioxarray.RasterArray.to_raster)\n",
+    "- Dataset: [rio.to_raster()](../rioxarray.rst#rioxarray.rioxarray.RasterDataset.to_raster)\n"
    ]
   },
   {
@@ -19,10 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import rioxarray\n",
-    "import rasterio\n",
-    "import xarray\n",
-    "import re"
+    "import rioxarray"
    ]
   },
   {
@@ -43,11 +45,12 @@
        "<pre>&lt;xarray.Dataset&gt;\n",
        "Dimensions:      (time: 2, x: 10, y: 10)\n",
        "Coordinates:\n",
-       "  * time         (time) object 2016-12-19 10:27:29 2016-12-29 12:52:41.659696\n",
        "  * y            (y) float64 8.085e+06 8.085e+06 ... 8.085e+06 8.085e+06\n",
        "  * x            (x) float64 4.663e+05 4.663e+05 ... 4.663e+05 4.663e+05\n",
+       "  * time         (time) object 2016-12-19 10:27:29 2016-12-29 12:52:41.659696\n",
        "    spatial_ref  int64 0\n",
        "Data variables:\n",
+       "    blue         (time, y, x) float64 ...\n",
        "    green        (time, y, x) float64 ...\n",
        "Attributes:\n",
        "    coordinates:  spatial_ref</pre>"
@@ -56,11 +59,12 @@
        "<xarray.Dataset>\n",
        "Dimensions:      (time: 2, x: 10, y: 10)\n",
        "Coordinates:\n",
-       "  * time         (time) object 2016-12-19 10:27:29 2016-12-29 12:52:41.659696\n",
        "  * y            (y) float64 8.085e+06 8.085e+06 ... 8.085e+06 8.085e+06\n",
        "  * x            (x) float64 4.663e+05 4.663e+05 ... 4.663e+05 4.663e+05\n",
+       "  * time         (time) object 2016-12-19 10:27:29 2016-12-29 12:52:41.659696\n",
        "    spatial_ref  int64 0\n",
        "Data variables:\n",
+       "    blue         (time, y, x) float64 ...\n",
        "    green        (time, y, x) float64 ...\n",
        "Attributes:\n",
        "    coordinates:  spatial_ref"
@@ -74,7 +78,6 @@
    "source": [
     "rds = rioxarray.open_rasterio(\n",
     "    \"../../test/test_data/input/PLANET_SCOPE_3D.nc\",\n",
-    "    variable=[\"green\"],\n",
     ")\n",
     "rds"
    ]
@@ -83,110 +86,60 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Managing Information Loss with xarray operations\n",
+    "## Converting Dataset to raster\n",
     "\n",
-    "Sometimes, you can lose important information from your dataset when performing operations.\n",
-    "You will likely want to keep track of your `nodata` and your `CRS`.\n",
-    "\n",
-    "API Reference:\n",
-    "\n",
-    "- [rio.to_raster()](../rioxarray.rst#rioxarray.rioxarray.RasterArray.to_raster)\n",
-    "- [rio.write_crs()](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.write_crs)\n",
-    "- [rio.update_attrs()](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.update_attrs)\n",
-    "- [rio.crs](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.crs)\n",
-    "- [rio.nodata](../rioxarray.rst#rioxarray.rioxarray.RasterArray.nodata)"
+    "Dataset: [rio.to_raster()](../rioxarray.rst#rioxarray.rioxarray.RasterDataset.to_raster)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "({}, CRS.from_epsg(32722), None)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "new_ds = rds.green + rds.green\n",
-    "new_ds.attrs, new_ds.rio.crs, new_ds.rio.nodata"
+    "# note how one time slice was selected on export to make the dataset 2D\n",
+    "rds.isel(time=0).rio.to_raster(\"planet_scope.tif\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"count\": 2, \"crs\": \"EPSG:32722\", \"descriptions\": [\"blue\", \"green\"], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"lnglat\": [-51.31732641226951, -17.322997474192466], \"mask_flags\": [[\"nodata\"], [\"nodata\"]], \"nodata\": NaN, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": false, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
+     ]
+    }
+   ],
    "source": [
-    "new_ds.rio.to_raster(\"combination.tif\")"
+    "!rio info planet_scope.tif"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Converting DataArray to raster\n",
+    "\n",
+    "DataArray: [rio.to_raster()](../rioxarray.rst#rioxarray.rioxarray.RasterArray.to_raster)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"count\": 2, \"crs\": \"EPSG:32722\", \"descriptions\": [\"green\", \"green\"], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"lnglat\": [-51.31732641226951, -17.322997474192466], \"mask_flags\": [[\"all_valid\"], [\"all_valid\"]], \"nodata\": null, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": false, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!rio info combination.tif"
+    "# note how selecting one variable allowed for multiple time steps in a single raster\n",
+    "rds.green.rio.to_raster(\"planet_scope_green.tif\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "({'grid_mapping': 'spatial_ref',\n",
-       "  'nodata': 0,\n",
-       "  'units': ('DN', 'DN'),\n",
-       "  '_FillValue': nan,\n",
-       "  'transform': (3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0),\n",
-       "  'scale_factor': 1.0,\n",
-       "  'add_offset': 0.0},\n",
-       " CRS.from_epsg(32722),\n",
-       " nan)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "new_ds = rds.green + rds.green\n",
-    "new_ds.rio.write_crs(rds.green.rio.crs, inplace=True)\n",
-    "new_ds.rio.update_attrs(rds.green.attrs, inplace=True)\n",
-    "new_ds.attrs, new_ds.rio.crs, new_ds.rio.nodata"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "new_ds.rio.to_raster(\"combination_keep_attrs.tif\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -198,7 +151,7 @@
     }
    ],
    "source": [
-    "!rio info combination_keep_attrs.tif"
+    "!rio info planet_scope_green.tif"
    ]
   }
  ],
@@ -218,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/examples.rst
+++ b/docs/examples/examples.rst
@@ -10,6 +10,7 @@ This page contains links to a collection of examples of how to use rioxarray.
    :caption: Notebooks:
 
    crs_management.ipynb
+   manage_information_loss.ipynb
    clip_geom.ipynb
    clip_box.ipynb
    reproject.ipynb

--- a/docs/examples/manage_information_loss.ipynb
+++ b/docs/examples/manage_information_loss.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Managing Information Loss with xarray operations\n",
+    "\n",
+    "Sometimes, you can lose important information from your dataset when performing operations.\n",
+    "You will likely want to keep track of the attributes, `nodata`, and `CRS`.\n",
+    "\n",
+    "API Reference:\n",
+    "\n",
+    "- [rio.to_raster()](../rioxarray.rst#rioxarray.rioxarray.RasterDataset.to_raster)\n",
+    "- [rio.write_crs()](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.write_crs)\n",
+    "- [rio.update_attrs()](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.update_attrs)\n",
+    "- [rio.crs](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.crs)\n",
+    "- [rio.nodata](../rioxarray.rst#rioxarray.rioxarray.RasterArray.nodata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rioxarray"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See docs for [rioxarray.open_rasterio](../rioxarray.rst#rioxarray-open-rasterio)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rds = rioxarray.open_rasterio(\n",
+    "    \"../../test/test_data/input/PLANET_SCOPE_3D.nc\",\n",
+    "    variable=[\"green\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice the original data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "({'grid_mapping': 'spatial_ref',\n",
+       "  'nodata': 0,\n",
+       "  'units': ('DN', 'DN'),\n",
+       "  '_FillValue': nan,\n",
+       "  'transform': (3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0),\n",
+       "  'scale_factor': 1.0,\n",
+       "  'add_offset': 0.0},\n",
+       " CRS.from_epsg(32722),\n",
+       " nan)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rds.green.attrs, rds.green.rio.crs, rds.green.rio.nodata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice how information is lost in the operation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "({}, CRS.from_epsg(32722), None)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_ds = rds.green + rds.green\n",
+    "new_ds.attrs, new_ds.rio.crs, new_ds.rio.nodata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The solution is to save the original attributes and then copy them over\n",
+    "once the operation is complete:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "({'grid_mapping': 'spatial_ref',\n",
+       "  'nodata': 0,\n",
+       "  'units': ('DN', 'DN'),\n",
+       "  '_FillValue': nan,\n",
+       "  'transform': (3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0),\n",
+       "  'scale_factor': 1.0,\n",
+       "  'add_offset': 0.0},\n",
+       " CRS.from_epsg(32722),\n",
+       " nan)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_ds = rds.green + rds.green\n",
+    "new_ds.rio.write_crs(rds.green.rio.crs, inplace=True)\n",
+    "new_ds.rio.update_attrs(rds.green.attrs, inplace=True)\n",
+    "new_ds.attrs, new_ds.rio.crs, new_ds.rio.nodata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_ds.rio.to_raster(\"combination_keep_attrs.tif\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"bounds\": [466266.0, 8084670.0, 466296.0, 8084700.0], \"colorinterp\": [\"gray\", \"undefined\"], \"count\": 2, \"crs\": \"EPSG:32722\", \"descriptions\": [\"green\", \"green\"], \"driver\": \"GTiff\", \"dtype\": \"float64\", \"height\": 10, \"indexes\": [1, 2], \"interleave\": \"pixel\", \"lnglat\": [-51.31732641226951, -17.322997474192466], \"mask_flags\": [[\"nodata\"], [\"nodata\"]], \"nodata\": NaN, \"res\": [3.0, 3.0], \"shape\": [10, 10], \"tiled\": false, \"transform\": [3.0, 0.0, 466266.0, 0.0, -3.0, 8084700.0, 0.0, 0.0, 1.0], \"units\": [null, null], \"width\": 10}\n"
+     ]
+    }
+   ],
+   "source": [
+    "!rio info combination_keep_attrs.tif"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.0.21
+-------
+- ENH: Added to_raster method for Datasets (issue #76)
+
 0.0.20
 ------
 - BUG: ensure band_key is list when iterating over bands for mask and scale (pull #87)

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -972,8 +972,7 @@ def test_to_raster__dataset__different_crs(tmpdir):
 def test_to_raster__dataset__different_nodata(tmpdir):
     tmp_raster = tmpdir.join("planet_3d_raster.tif")
     with xarray.open_dataset(
-        os.path.join(TEST_INPUT_DATA_DIR, "PLANET_SCOPE_3D.nc"),
-        mask_and_scale=False,
+        os.path.join(TEST_INPUT_DATA_DIR, "PLANET_SCOPE_3D.nc"), mask_and_scale=False,
     ) as mda:
         rds = mda.isel(time=0)
         rds.green.rio.write_nodata(1234, inplace=True)

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -810,7 +810,9 @@ def test_to_raster__custom_description(tmpdir):
         xds.attrs["long_name"] = ("one", "two")
         xds.rio.to_raster(str(tmp_raster))
         xds_attrs = {
-            key: str(value) for key, value in xds.attrs.items() if key != "nodata"
+            key: str(value)
+            for key, value in xds.attrs.items()
+            if key not in ("nodata", "long_name")
         }
 
     with rasterio.open(str(tmp_raster)) as rds:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #76
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Note: With the addition of the `to_raster()` dataset method, decided to moved the information loss section to its own notebook.