### PR TITLE
ENH: Use pyproj.CRS internally to manage GDAL 2/3 transition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 - conda config --add channels conda-forge
 - conda config --set channel_priority strict
 # Create conda environment
-- conda create -n test python=$PYTHON_VERSION pillow rasterio scipy xarray netcdf4 dask
+- conda create -n test python=$PYTHON_VERSION pillow rasterio scipy xarray netcdf4 dask pandoc
 - source activate test
 
 install:
@@ -53,12 +53,11 @@ install:
 script:
 - py.test --cov-report term-missing --cov=rioxarray
 - make check
+- make docs
 # Building and uploading docs with doctr
 - set -e
 - |
   if [ "$DOC" ]; then
-    sudo apt-get install -qq pandoc
-    make docs
     pip install doctr
     if [[ -z "$TRAVIS_TAG" ]]; then
       DEPLOY_DIR=latest;

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+0.0.22
+-------
+- ENH: Use pyproj.CRS internally to manage GDAL 2/3 transition (issue #92)
+- ENH: Add MissingCRS exceptions for 'rio.clip' and 'rio.reproject' (pull #93)
+
 0.0.21
 -------
 - ENH: Added to_raster method for Datasets (issue #76)

--- a/rioxarray/crs.py
+++ b/rioxarray/crs.py
@@ -2,16 +2,21 @@
 """
 This module contains helper methods for rasterio.crs.CRS.
 """
+from distutils.version import LooseVersion
+
+import rasterio
+from pyproj import CRS
 
 
-def crs_to_wkt(rasterio_crs):
+def crs_to_wkt(crs_input):
     """
-    This is to deal with change in rasterio.crs.CRS.
+    This is to deal with change in rasterio.crs.CRS
+    as well as to assist in the transition between GDAL 2/3.
 
     Parameters
     ----------
-    rasterio_crs: :obj:`rasterio.crs.CRS`
-        Rasterio object.
+    crs_input: Any
+        Input to create a CRS.
 
     Returns
     -------
@@ -19,7 +24,12 @@ def crs_to_wkt(rasterio_crs):
 
     """
     try:
-        # rasterio>=1.0.14
-        return rasterio_crs.to_wkt()
+        # rasterio.crs.CRS <1.0.14 and
+        # old versions of opendatacube CRS
+        crs_input = crs_input.wkt
     except AttributeError:
-        return rasterio_crs.wkt
+        pass
+    crs = CRS.from_user_input(crs_input)
+    if LooseVersion(rasterio.__gdal_version__) > LooseVersion("3.0.0"):
+        return crs.to_wkt()
+    return crs.to_wkt("WKT1_GDAL")

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version():
 with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-requirements = ["pillow", "rasterio", "scipy", "xarray"]
+requirements = ["pillow", "rasterio", "scipy", "xarray", "pyproj>=2"]
 
 test_requirements = ["pytest>=3.6", "pytest-cov", "mock"]
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #92
 - [x] Tests added
 - [x] Fully documented, including `whats-new.rst` for all changes and `api.rst` for new API

Also: Add MissingCRS exceptions for 'rio.clip' and 'rio.reproject'