### PR TITLE
ENH: added rioxarray.show_versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,6 +23,12 @@ http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
 
 
 #### Environment Information
+
+<!-- Only works with rioxarray >= 0.0.25 -->
+ - `python -c "import rioxarray; rioxarray.show_versions()"`
+
+<!-- For rioxarray < 0.0.25 -->
+
  - rioxarray version (`python -c "import rioxarray; print(rioxarray.__version__)"`)
  - rasterio version (`rio --version`)
  - GDAL version (`rio --gdal-version`)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+0.0.26
+------
+- ENH: Added :func:`rioxarray.show_versions` (issue #106)
+
 0.0.25
 ------
 - BUG: Use recalc=True when using transform internally & ensure stable when coordinates unavailable. (issue #97)

--- a/docs/rioxarray.rst
+++ b/docs/rioxarray.rst
@@ -15,6 +15,12 @@ rioxarray.merge module
 .. autofunction:: rioxarray.merge.merge_datasets
 
 
+rioxarray.show_versions
+-----------------------
+
+.. autofunction:: rioxarray.show_versions
+
+
 rioxarray.rioxarray module
 --------------------------
 

--- a/rioxarray/__init__.py
+++ b/rioxarray/__init__.py
@@ -6,6 +6,7 @@ __author__ = """rioxarray Contributors"""
 __email__ = "alansnow21@gmail.com"
 
 import rioxarray.rioxarray  # noqa
+from rioxarray._show_versions import show_versions  # noqa
 from rioxarray._version import __version__  # noqa
 
 try:

--- a/rioxarray/_show_versions.py
+++ b/rioxarray/_show_versions.py
@@ -1,0 +1,106 @@
+"""
+Utility methods to print system info for debugging
+
+adapted from :func:`sklearn.utils._show_versions`
+which was adapted from :func:`pandas.show_versions`
+"""
+import importlib
+import platform
+import sys
+
+
+def _get_sys_info():
+    """System information
+    Return
+    ------
+    sys_info : dict
+        system and Python version information
+    """
+    blob = [
+        ("python", sys.version.replace("\n", " ")),
+        ("executable", sys.executable),
+        ("machine", platform.platform()),
+    ]
+
+    return dict(blob)
+
+
+def _get_main_info():
+    """Get the main dependency information to hightlight.
+
+    Returns
+    -------
+    proj_info: dict
+        system GDAL information
+    """
+    import rasterio
+    import xarray
+
+    blob = [
+        ("rasterio", rasterio.__version__),
+        ("xarray", xarray.__version__),
+        ("GDAL", rasterio.__gdal_version__),
+    ]
+
+    return dict(blob)
+
+
+def _get_deps_info():
+    """Overview of the installed version of dependencies
+    Returns
+    -------
+    deps_info: dict
+        version information on relevant Python libraries
+    """
+    # Note: PIL is the module name, howerver pillow is the dependency
+    deps = ["PIL", "scipy", "pyproj"]
+
+    def get_version(module):
+        try:
+            return module.__version__
+        except AttributeError:
+            return module.version
+
+    deps_info = {}
+
+    for modname in deps:
+        try:
+            if modname in sys.modules:
+                mod = sys.modules[modname]
+            else:
+                mod = importlib.import_module(modname)
+            ver = get_version(mod)
+            # use PIL only to get version information
+            modname = "pillow" if modname == "PIL" else modname
+            deps_info[modname] = ver
+        except ImportError:
+            deps_info[modname] = None
+
+    return deps_info
+
+
+def _print_info_dict(info_dict):
+    """Print the information dictionary"""
+    for key, stat in info_dict.items():
+        print("{key:>10}: {stat}".format(key=key, stat=stat))
+
+
+def show_versions():
+    """
+    .. versionadded:: 0.0.26
+
+    Print useful debugging information
+
+    Example
+    -------
+    > python -c "import rioxarray; rioxarray.show_versions()"
+
+    """
+    import rioxarray
+
+    print(f"rioxarray ({rioxarray.__version__}) deps:")
+    _print_info_dict(_get_main_info())
+    print("\nOther python deps:")
+    _print_info_dict(_get_deps_info())
+    print("\nSystem:")
+    _print_info_dict(_get_sys_info())

--- a/test/unit/test_show_versions.py
+++ b/test/unit/test_show_versions.py
@@ -1,0 +1,39 @@
+from rioxarray._show_versions import (
+    _get_deps_info,
+    _get_main_info,
+    _get_sys_info,
+    show_versions,
+)
+
+
+def test_get_main_info():
+    pyproj_info = _get_main_info()
+    assert "rasterio" in pyproj_info
+    assert "xarray" in pyproj_info
+    assert "GDAL" in pyproj_info
+
+
+def test_get_sys_info():
+    sys_info = _get_sys_info()
+
+    assert "python" in sys_info
+    assert "executable" in sys_info
+    assert "machine" in sys_info
+
+
+def test_get_deps_info():
+    deps_info = _get_deps_info()
+
+    assert "pillow" in deps_info
+    assert "scipy" in deps_info
+    assert "pyproj" in deps_info
+
+
+def test_show_versions_with_proj(capsys):
+    show_versions()
+    out, err = capsys.readouterr()
+    assert "System" in out
+    assert "python" in out
+    assert "GDAL" in out
+    assert "rioxarray" in out
+    assert "Other python deps" in out


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

TODO: Change PR to master branch once #109 is merged.

 - [x] Closes #106
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

```
$ python -c "import rioxarray; rioxarray.show_versions()"
rioxarray (0.0.25) deps:
  rasterio: 1.1.3
    xarray: 0.15.1
      GDAL: 3.0.4

Other python deps:
    pillow: 7.0.0
     scipy: 1.4.1
    pyproj: 2.6.0

System:
    python: 3.8.2 | packaged by conda-forge | (default, Mar 23 2020, 18:16:37)  [GCC 7.3.0]
executable: /home/snowal/miniconda/envs/rioxarray/bin/python
   machine: Linux-4.15.0-96-generic-x86_64-with-glibc2.10
```