### PR TITLE
Allow destination shape to be specified in reproject()

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+Unreleased
+----------
+
+- ENH: Added optional `shape` argument to `rio.reproject` (pull #116)
+
 0.0.26
 ------
 - ENH: Added :func:`rioxarray.show_versions` (issue #106)

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -209,12 +209,16 @@ def _make_dst_affine(
     """Determine the affine of the new projected `xarray.DataArray`"""
     src_bounds = src_data_array.rio.bounds()
     src_width, src_height = src_data_array.rio.shape
-    resolution_or_width_height = {}
-    if dst_resolution is not None:
-        resolution_or_width_height["resolution"] = dst_resolution
-    if dst_shape is not None:
-        resolution_or_width_height["dst_height"] = dst_shape[0]
-        resolution_or_width_height["dst_width"] = dst_shape[1]
+    dst_height, dst_width = dst_shape if dst_shape is not None else (None, None)
+    resolution_or_width_height = {
+        k: v
+        for k, v in [
+            ("resolution", dst_resolution),
+            ("dst_height", dst_height),
+            ("dst_width", dst_width),
+        ]
+        if v is not None
+    }
     dst_affine, dst_width, dst_height = rasterio.warp.calculate_default_transform(
         src_crs,
         dst_crs,

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -211,13 +211,17 @@ def _make_dst_affine(
     src_width, src_height = src_data_array.rio.shape
     resolution_or_width_height = {}
     if dst_resolution is not None:
-        resolution_or_width_height['resolution'] = dst_resolution
+        resolution_or_width_height["resolution"] = dst_resolution
     if dst_shape is not None:
-        resolution_or_width_height['dst_height'] = dst_shape[0]
-        resolution_or_width_height['dst_width'] = dst_shape[1]
+        resolution_or_width_height["dst_height"] = dst_shape[0]
+        resolution_or_width_height["dst_width"] = dst_shape[1]
     dst_affine, dst_width, dst_height = rasterio.warp.calculate_default_transform(
-        src_crs, dst_crs, src_width, src_height, *src_bounds,
-        **resolution_or_width_height
+        src_crs,
+        dst_crs,
+        src_width,
+        src_height,
+        *src_bounds,
+        **resolution_or_width_height,
     )
     return dst_affine, dst_width, dst_height
 
@@ -895,9 +899,7 @@ class RasterArray(XRasterBase):
 
         """
         if resolution is not None and shape is not None:
-            raise RioXarrayError(
-                "resolution and shape cannot be used together."
-            )
+            raise RioXarrayError("resolution and shape cannot be used together.")
         if self.crs is None:
             raise MissingCRS(
                 "CRS not found. Please set the CRS with 'set_crs()' or 'write_crs()'."

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -878,6 +878,8 @@ class RasterArray(XRasterBase):
             a 'crs' attribute to be set containing a valid CRS.
             If using a WKT (e.g. from spatiareference.org), make sure it is an OGC WKT.
 
+        .. versionadded:: 0.0.27 shape
+
         Parameters
         ----------
         dst_crs: str
@@ -886,7 +888,8 @@ class RasterArray(XRasterBase):
             Size of a destination pixel in destination projection units
             (e.g. degrees or metres).
         shape: tuple(int, int), optional
-            Shape of the destination in pixels. Cannot be used together with resolution.
+            Shape of the destination in pixels (dst_height, dst_width). Cannot be used
+            together with resolution.
         dst_affine_width_height: tuple(dst_affine, dst_width, dst_height), optional
             Tuple with the destination affine, width, and height.
         resampling: Resampling method, optional
@@ -1415,6 +1418,7 @@ class RasterDataset(XRasterBase):
             a 'crs' attribute to be set containing a valid CRS.
             If using a WKT (e.g. from spatiareference.org), make sure it is an OGC WKT.
 
+        .. versionadded:: 0.0.27 shape
 
         Parameters
         ----------
@@ -1424,7 +1428,8 @@ class RasterDataset(XRasterBase):
             Size of a destination pixel in destination projection units
             (e.g. degrees or metres).
         shape: tuple(int, int), optional
-            Shape of the destination in pixels. Cannot be used together with resolution.
+            Shape of the destination in pixels (dst_height, dst_width). Cannot be used
+            together with resolution.
         dst_affine_width_height: tuple(dst_affine, dst_width, dst_height), optional
             Tuple with the destination affine, width, and height.
         resampling: Resampling method, optional

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -203,18 +203,21 @@ def _make_coords(src_data_array, dst_affine, dst_width, dst_height, dst_crs):
     return add_xy_grid_meta(new_coords)
 
 
-def _make_dst_affine(src_data_array, src_crs, dst_crs, dst_resolution=None, dst_shape=None):
+def _make_dst_affine(
+    src_data_array, src_crs, dst_crs, dst_resolution=None, dst_shape=None
+):
     """Determine the affine of the new projected `xarray.DataArray`"""
     src_bounds = src_data_array.rio.bounds()
     src_width, src_height = src_data_array.rio.shape
     resolution_or_width_height = {}
     if dst_resolution is not None:
-        resolution_or_width_height['resolution'] = des_resolution
+        resolution_or_width_height['resolution'] = dst_resolution
     if dst_shape is not None:
         resolution_or_width_height['dst_height'] = dst_shape[0]
         resolution_or_width_height['dst_width'] = dst_shape[1]
     dst_affine, dst_width, dst_height = rasterio.warp.calculate_default_transform(
-        src_crs, dst_crs, src_width, src_height, *src_bounds, **resolution_or_width_height
+        src_crs, dst_crs, src_width, src_height, *src_bounds,
+        **resolution_or_width_height
     )
     return dst_affine, dst_width, dst_height
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ extras_require = {
         "nbsphinx",
         "sphinx_rtd_theme",
         "black",
-        "flake8",
+        "flake8==3.7",
         "pylint",
         "isort",
         "pre-commit",

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1256,6 +1256,17 @@ def test_reproject_missing_crs():
         test_da.rio.reproject(4326)
 
 
+def test_reproject_resolution_and_shape():
+    test_da = xarray.DataArray(
+        numpy.zeros((5, 5)),
+        dims=("y", "x"),
+        coords={"y": numpy.arange(1, 6), "x": numpy.arange(2, 7)},
+        attrs={'crs': '+init=epsg:3857'}
+    )
+    with pytest.raises(RioXarrayError):
+        test_da.rio.reproject(4326, resolution=1, shape=(1, 1))
+
+
 class CustomCRS(object):
     @property
     def wkt(self):

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -348,6 +348,25 @@ def test_transform_bounds():
         )
 
 
+def test_reproject_with_shape(modis_reproject):
+    new_shape = (9, 10)
+    mask_args = (
+        dict(masked=False)
+        if "open_rasterio" in str(modis_reproject["open"])
+        else dict(mask_and_scale=False)
+    )
+    with modis_reproject["open"](
+        modis_reproject["input"], **mask_args
+    ) as mda:
+        mds_repr = mda.rio.reproject(modis_reproject["to_proj"], shape=new_shape)
+        # test
+        if hasattr(mds_repr, "variables"):
+            for var in mds_repr.rio.vars:
+                assert mds_repr[var].shape == new_shape
+        else:
+            assert mds_repr.shape == new_shape
+
+
 def test_reproject(modis_reproject):
     mask_args = (
         dict(masked=False)

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1261,7 +1261,7 @@ def test_reproject_resolution_and_shape():
         numpy.zeros((5, 5)),
         dims=("y", "x"),
         coords={"y": numpy.arange(1, 6), "x": numpy.arange(2, 7)},
-        attrs={'crs': '+init=epsg:3857'}
+        attrs={"crs": "+init=epsg:3857"},
     )
     with pytest.raises(RioXarrayError):
         test_da.rio.reproject(4326, resolution=1, shape=(1, 1))

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -355,9 +355,7 @@ def test_reproject_with_shape(modis_reproject):
         if "open_rasterio" in str(modis_reproject["open"])
         else dict(mask_and_scale=False)
     )
-    with modis_reproject["open"](
-        modis_reproject["input"], **mask_args
-    ) as mda:
+    with modis_reproject["open"](modis_reproject["input"], **mask_args) as mda:
         mds_repr = mda.rio.reproject(modis_reproject["to_proj"], shape=new_shape)
         # test
         if hasattr(mds_repr, "variables"):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
