### PR TITLE
RasterioDeprecationWarning

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -654,7 +654,7 @@ def open_rasterio(
             crs=vrt.crs.to_string(),
             resampling=vrt.resampling,
             src_nodata=vrt.src_nodata,
-            dst_nodata=vrt.dst_nodata,
+            nodata=vrt.nodata,
             tolerance=vrt.tolerance,
             transform=vrt.transform,
             width=vrt.width,


### PR DESCRIPTION
Following the discussion on [xarray](https://github.com/pydata/xarray/pull/3964), this PR addresses the RasterioDeprecationWarning.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
