### PR TITLE
Fix open_rasterio() for WarpedVRT with specified src_crs

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ History
 - ENH: Added optional `shape` argument to `rio.reproject` (pull #116)
 - Fix ``RasterioDeprecationWarning`` (pull #117)
 - BUG: Make rio.shape order same as rasterio dataset shape (height, width) (pull #121)
+- Fix open_rasterio() for WarpedVRT with specified src_crs (pydata/xarray/pull/4104 & pull 120)
 
 0.0.26
 ------

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -651,14 +651,17 @@ def open_rasterio(
         vrt = filename
         filename = vrt.src_dataset.name
         vrt_params = dict(
+            src_crs=vrt.src_crs.to_string(),
             crs=vrt.crs.to_string(),
             resampling=vrt.resampling,
+            tolerance=vrt.tolerance,
             src_nodata=vrt.src_nodata,
             nodata=vrt.nodata,
-            tolerance=vrt.tolerance,
-            transform=vrt.transform,
             width=vrt.width,
             height=vrt.height,
+            src_transform=vrt.src_transform,
+            transform=vrt.transform,
+            dtype=vrt.working_dtype,
             warp_extras=vrt.warp_extras,
         )
 

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -859,8 +859,6 @@ class TestRasterio:
 
     def test_rasterio_vrt_with_src_crs(self):
         # Test open_rasterio() support of WarpedVRT with specified src_crs
-        import rasterio
-
         # create geotiff with no CRS and specify it manually
         with create_tmp_geotiff(crs=None) as (tmp_file, expected):
             src_crs = rasterio.crs.CRS.from_epsg(32618)

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -857,6 +857,19 @@ class TestRasterio:
                         assert_equal(actual_res, expected_res)
                         assert_equal(expected_val, actual_val)
 
+    def test_rasterio_vrt_with_src_crs(self):
+        # Test open_rasterio() support of WarpedVRT with specified src_crs
+        import rasterio
+
+        # create geotiff with no CRS and specify it manually
+        with create_tmp_geotiff(crs=None) as (tmp_file, expected):
+            src_crs = rasterio.crs.CRS.from_epsg(32618)
+            with rasterio.open(tmp_file) as src:
+                assert src.crs is None
+                with rasterio.vrt.WarpedVRT(src, src_crs=src_crs) as vrt:
+                    with rioxarray.open_rasterio(vrt) as da:
+                        assert da.rio.crs == src_crs
+
 
 def test_open_cog():
     cog_file = os.path.join(TEST_INPUT_DATA_DIR, "cog.tif")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] From pydata/xarray/pull/4104
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
