### PR TITLE
BUG: Make rio.shape order same as rasterio dataset shape (height, width)

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ History
 
 - ENH: Added optional `shape` argument to `rio.reproject` (pull #116)
 - Fix ``RasterioDeprecationWarning`` (pull #117)
+- BUG: Make rio.shape order same as rasterio dataset shape (height, width) (pull #121)
 
 0.0.26
 ------

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -208,7 +208,7 @@ def _make_dst_affine(
 ):
     """Determine the affine of the new projected `xarray.DataArray`"""
     src_bounds = src_data_array.rio.bounds()
-    src_width, src_height = src_data_array.rio.shape
+    src_height, src_width = src_data_array.rio.shape
     dst_height, dst_width = dst_shape if dst_shape is not None else (None, None)
     resolution_or_width_height = {
         k: v
@@ -570,8 +570,8 @@ class XRasterBase(object):
 
     @property
     def shape(self):
-        """tuple: Returns the shape (width, height)"""
-        return (self.width, self.height)
+        """tuple(int, int): Returns the shape (height, width)"""
+        return (self.height, self.width)
 
     def isel_window(self, window):
         """
@@ -1000,7 +1000,7 @@ class RasterArray(XRasterBase):
         """
         dst_crs = crs_to_wkt(match_data_array.rio.crs)
         dst_affine = match_data_array.rio.transform(recalc=True)
-        dst_width, dst_height = match_data_array.rio.shape
+        dst_height, dst_width = match_data_array.rio.shape
 
         return self.reproject(
             dst_crs,

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1616,3 +1616,8 @@ def test_missing_transform_resolution():
     xds.attrs.pop("transform")
     with pytest.raises(DimensionMissingCoordinateError):
         xds.rio.resolution()
+
+
+def test_shape_order():
+    rds = rioxarray.open_rasterio(os.path.join(TEST_INPUT_DATA_DIR, "tmmx_20190121.nc"))
+    assert rds.air_temperature.rio.shape == (585, 1386)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
