### PR TITLE
rio.reproject: change input kwarg dst_affine_width_height -> shape & transform

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,7 @@ History
 
 Latest
 -------
-
+- rio.reproject: change input kwarg dst_affine_width_height -> shape & transform (#125)
 
 0.0.27
 ------

--- a/rioxarray/merge.py
+++ b/rioxarray/merge.py
@@ -40,7 +40,8 @@ class RasterioDatasetDuck:
                 out_height, out_width = out_shape
             data_window = self._xds.rio.reproject(
                 self._xds.rio.crs,
-                dst_affine_width_height=(self.transform, out_width, out_height),
+                transform=self.transform,
+                shape=(out_height, out_width),
             )
 
         nodata = self.nodatavals[0]

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -906,8 +906,8 @@ class RasterArray(XRasterBase):
         :class:`xarray.DataArray`: A reprojected DataArray.
 
         """
-        if resolution is not None and shape is not None:
-            raise RioXarrayError("resolution and shape cannot be used together.")
+        if resolution is not None and (shape is not None or transform is not None):
+            raise RioXarrayError("resolution cannot be used with shape or transform.")
         if self.crs is None:
             raise MissingCRS(
                 "CRS not found. Please set the CRS with 'set_crs()' or 'write_crs()'."

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -896,7 +896,7 @@ class RasterArray(XRasterBase):
             Shape of the destination in pixels (dst_height, dst_width). Cannot be used
             together with resolution.
         transform, optional
-            The destination transform. shape is required if included.
+            The destination transform.
         resampling: Resampling method, optional
             See rasterio.warp.reproject for more details.
 
@@ -918,11 +918,12 @@ class RasterArray(XRasterBase):
             dst_affine, dst_width, dst_height = _make_dst_affine(
                 self._obj, self.crs, dst_crs, resolution, shape
             )
-        elif transform is not None and shape is not None:
-            dst_affine = transform
-            dst_height, dst_width = shape
         else:
-            raise RioXarrayError("shape is required if transform is set.")
+            dst_affine = transform
+            if shape is not None:
+                dst_height, dst_width = shape
+            else:
+                dst_height, dst_width = self.shape
 
         extra_dim = self._check_dimensions()
         if extra_dim:
@@ -1439,7 +1440,7 @@ class RasterDataset(XRasterBase):
             Shape of the destination in pixels (dst_height, dst_width). Cannot be used
             together with resolution.
         transform, optional
-            The destination transform. shape is required if included.
+            The destination transform.
         resampling: Resampling method, optional
             See rasterio.warp.reproject for more details.
 

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1278,10 +1278,21 @@ def test_reproject_resolution_and_shape():
         numpy.zeros((5, 5)),
         dims=("y", "x"),
         coords={"y": numpy.arange(1, 6), "x": numpy.arange(2, 7)},
-        attrs={"crs": "+init=epsg:3857"},
+        attrs={"crs": "epsg:3857"},
     )
     with pytest.raises(RioXarrayError):
         test_da.rio.reproject(4326, resolution=1, shape=(1, 1))
+
+
+def test_reproject_transform_missing_shape():
+    test_da = xarray.DataArray(
+        numpy.zeros((5, 5)),
+        dims=("y", "x"),
+        coords={"y": numpy.arange(1, 6), "x": numpy.arange(2, 7)},
+        attrs={"crs": "epsg:3857"},
+    )
+    with pytest.raises(RioXarrayError):
+        test_da.rio.reproject(4326, transform=test_da.rio.transform())
 
 
 class CustomCRS(object):

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1291,8 +1291,10 @@ def test_reproject_transform_missing_shape():
         coords={"y": numpy.arange(1, 6), "x": numpy.arange(2, 7)},
         attrs={"crs": "epsg:3857"},
     )
-    with pytest.raises(RioXarrayError):
-        test_da.rio.reproject(4326, transform=test_da.rio.transform())
+    affine = Affine.from_gdal(0, 0.005, 0, 0, 0, 0.005)
+    reprojected = test_da.rio.reproject(4326, transform=affine)
+    assert reprojected.rio.shape == (5, 5)
+    assert reprojected.rio.transform() == affine
 
 
 class CustomCRS(object):

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1273,15 +1273,20 @@ def test_reproject_missing_crs():
         test_da.rio.reproject(4326)
 
 
-def test_reproject_resolution_and_shape():
+def test_reproject_resolution_and_shape_transform():
     test_da = xarray.DataArray(
         numpy.zeros((5, 5)),
         dims=("y", "x"),
         coords={"y": numpy.arange(1, 6), "x": numpy.arange(2, 7)},
         attrs={"crs": "epsg:3857"},
     )
+    affine = Affine.from_gdal(0, 0.005, 0, 0, 0, 0.005)
     with pytest.raises(RioXarrayError):
         test_da.rio.reproject(4326, resolution=1, shape=(1, 1))
+    with pytest.raises(RioXarrayError):
+        test_da.rio.reproject(4326, resolution=1, transform=affine)
+    with pytest.raises(RioXarrayError):
+        test_da.rio.reproject(4326, resolution=1, shape=(1, 1), transform=affine)
 
 
 def test_reproject_transform_missing_shape():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

With #116 and #121, I think this makes more sense. Also, the `dst_affine_width_height` version argument was pretty awkward, I don't like it, and I would be surprised if anyone was using it.

 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
