### PR TITLE
BUG: Allow clipping with disjoint geometries

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,8 @@ History
 
 Latest
 -------
-
+- BUG: Fix order of axis in `rio.isel_window` (pull #133)
+- BUG: Allow clipping with disjoint geometries (issue #132)
 
 0.0.28
 -------

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1448,8 +1448,8 @@ def test_isel_window():
         os.path.join(TEST_INPUT_DATA_DIR, "MODIS_ARRAY.nc")
     ) as mda:
         assert (
-            mda.rio.isel_window(Window.from_slices(slice(10, 12), slice(10, 12)))
-            == mda.isel(x=slice(10, 12), y=slice(10, 12))
+            mda.rio.isel_window(Window.from_slices(slice(9, 12), slice(10, 12)))
+            == mda.isel(x=slice(10, 12), y=slice(9, 12))
         ).all()
 
 
@@ -1597,9 +1597,9 @@ def test_nonstandard_dims_isel_window():
     ) as xds:
         reprojected = xds.rio.set_spatial_dims(
             x_dim="lon", y_dim="lat"
-        ).rio.isel_window(Window.from_slices(slice(5), slice(5)))
+        ).rio.isel_window(Window.from_slices(slice(4), slice(5)))
         assert reprojected.rio.width == 5
-        assert reprojected.rio.height == 5
+        assert reprojected.rio.height == 4
 
 
 def test_nonstandard_dims_error_msg():


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #132 
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API


Also, found a bug in `rio.isel_window` in this process that has been addressed in this PR.