### PR TITLE
BUG: Remove automatically setting tiled=True for windowed writing

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Latest
 -------
 - BUG: Fix order of axis in `rio.isel_window` (pull #133)
 - BUG: Allow clipping with disjoint geometries (issue #132)
+- BUG: Remove automatically setting tiled=True for windowed writing (pull #134)
 
 0.0.28
 -------

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -12,7 +12,6 @@ datacube is licensed under the Apache License, Version 2.0:
 """
 import copy
 import math
-import warnings
 from uuid import uuid4
 
 import numpy as np
@@ -1351,9 +1350,6 @@ class RasterArray(XRasterBase):
                 "dtype",
             )
         }
-        if windowed and not out_profile.get("tiled"):
-            warnings.warn("Set tiled=True for windowed writing.")
-            out_profile["tiled"] = True
         with rasterio.open(
             raster_path,
             "w",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Tests used to fail without this. The `isel_window` fix in #132 removed the need for this.

 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
