### PR TITLE
ENH: Default rio.clip to assume geometry has CRS of dataset

### DIFF
--- a/docs/examples/clip_geom.ipynb
+++ b/docs/examples/clip_geom.ipynb
@@ -114,6 +114,9 @@
    "source": [
     "## Clip using a geometry\n",
     "\n",
+    "By default, it assumes that the CRS of the geometry is the same as the CRS\n",
+    "of the dataset. If it is different, make sure to pass in the CRS of the geometry.\n",
+    "\n",
     "API Reference for `rio.clip`:\n",
     "\n",
     "  - [DataArray.clip](../rioxarray.rst#rioxarray.rioxarray.RasterArray.clip)\n",
@@ -146,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "clipped = xds.rio.clip(geometries, xds.rio.crs)"
+    "clipped = xds.rio.clip(geometries)"
    ]
   },
   {
@@ -324,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -11,7 +11,7 @@ Latest
 - ENH: Add `rio.count`, `rio.slice_xy()`, `rio.bounds()`, `rio.resolution()`, `rio.transform_bounds()` to Dataset level
 - ENH: Add `rio.write_coordinate_system()` (issue #147)
 - ENH: Search CF coordinate metadata to find coordinates (issue #147)
-- ENH: Default `rio.clip` to assume geometry has CRS of dataset
+- ENH: Default `rio.clip` to assume geometry has CRS of dataset (pull #150)
 
 0.0.29
 -------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -11,6 +11,7 @@ Latest
 - ENH: Add `rio.count`, `rio.slice_xy()`, `rio.bounds()`, `rio.resolution()`, `rio.transform_bounds()` to Dataset level
 - ENH: Add `rio.write_coordinate_system()` (issue #147)
 - ENH: Search CF coordinate metadata to find coordinates (issue #147)
+- ENH: Default `rio.clip` to assume geometry has CRS of dataset
 
 0.0.29
 -------

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -399,13 +399,11 @@ def test_clip_geojson(open_func):
             }
         ]
         # test data array
-        clipped = xdi.rio.clip(geometries, comp_subset.rio.crs)
+        clipped = xdi.rio.clip(geometries)
         _assert_xarrays_equal(clipped, comp_subset)
 
         # test dataset
-        clipped_ds = xdi.to_dataset(name="test_data").rio.clip(
-            geometries, subset.rio.crs
-        )
+        clipped_ds = xdi.to_dataset(name="test_data").rio.clip(geometries)
         comp_subset_ds = comp_subset.to_dataset(name="test_data")
         # This coordinate checking is skipped when parse_coordinates=False
         # as the auto-generated coordinates differ and can be ignored
@@ -1669,11 +1667,7 @@ def test_nonstandard_dims_clip__dataset():
     ) as xds:
         xds.coords["lon"].attrs = {}
         xds.coords["lat"].attrs = {}
-        clipped = (
-            xds.rio.set_spatial_dims(x_dim="lon", y_dim="lat")
-            .rio.write_crs("EPSG:4326")
-            .rio.clip([geom], "EPSG:4326")
-        )
+        clipped = xds.rio.set_spatial_dims(x_dim="lon", y_dim="lat").rio.clip([geom])
         assert clipped.rio.width == 6
         assert clipped.rio.height == 5
 
@@ -1688,12 +1682,7 @@ def test_nonstandard_dims_clip__array():
         xds.coords["lat"].attrs = {}
         clipped = xds.analysed_sst.rio.set_spatial_dims(
             x_dim="lon", y_dim="lat"
-        ).rio.clip([geom], "EPSG:4326")
-        clipped = (
-            xds.analysed_sst.rio.set_spatial_dims(x_dim="lon", y_dim="lat")
-            .rio.write_crs("EPSG:4326")
-            .rio.clip([geom], "EPSG:4326")
-        )
+        ).rio.clip([geom])
         assert clipped.rio.width == 6
         assert clipped.rio.height == 5
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests updated
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

Benefits:
- Nice to have shorthand version
- Requiring the CRS has caused confusion for some in the example when the CRS is passed in from the dataset. Hopefully this will help with that.
- Matches behavior of `rio.clip_box`.