### PR TITLE
TST: Allow interpolate_na_veris test to xfail if not on linux

### DIFF
--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -875,7 +875,7 @@ def test_interpolate_na(interpolate_na):
 
 
 @pytest.mark.xfail(
-    LooseVersion(scipy.__version__) < LooseVersion("1.5.0") or os.name == "nt",
+    LooseVersion(scipy.__version__) < LooseVersion("1.5.0") or os.name != "posix",
     reason="griddata behaves differently across versions and platforms",
 )
 def test_interpolate_na_veris(interpolate_na_veris):

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 from distutils.version import LooseVersion
 from functools import partial
 
@@ -875,7 +876,8 @@ def test_interpolate_na(interpolate_na):
 
 
 @pytest.mark.xfail(
-    LooseVersion(scipy.__version__) < LooseVersion("1.5.0") or os.name != "posix",
+    LooseVersion(scipy.__version__) < LooseVersion("1.5.0")
+    or platform.system() != "Linux",
     reason="griddata behaves differently across versions and platforms",
 )
 def test_interpolate_na_veris(interpolate_na_veris):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Different results on OSX and Windows. So, deciding to focus mainly on Linux for testing.