### PR TITLE
BUG: Ensure transform correct in rio.clip without coords

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- BUG: Ensure transform correct in rio.clip without coords (pull #165)
 
 0.0.31
 ------

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -1528,10 +1528,6 @@ class RasterArray(XRasterBase):
         )
         clip_mask_xray = xarray.DataArray(
             clip_mask_arr,
-            coords={
-                self.y_dim: self._obj.coords[self.y_dim],
-                self.x_dim: self._obj.coords[self.x_dim],
-            },
             dims=(self.y_dim, self.x_dim),
         )
         cropped_ds = self._obj.where(clip_mask_xray)

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -409,6 +409,11 @@ def test_clip_geojson(open_func):
         _assert_xarrays_equal(
             clipped_ds, comp_subset_ds, skip_xy_check=isinstance(open_func, partial)
         )
+        # check the transform
+        assert_almost_equal(
+            clipped_ds.rio.transform(),
+            (3.0, 0.0, 425500.68381405267, 0.0, -3.0, 4615477.040546387, 0.0, 0.0, 1.0),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #164
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
