### PR TITLE
BUG: Ensure the nodata value matches the dtype

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 Latest
 ------
 - BUG: Ensure transform correct in rio.clip without coords (pull #165)
+- BUG: Ensure the nodata value matches the dtype (pull #166)
 
 0.0.31
 ------

--- a/test/integration/test_integration_merge.py
+++ b/test/integration/test_integration_merge.py
@@ -81,6 +81,7 @@ def test_merge_arrays__res():
     assert merged.coords["band"].values == [1]
     assert sorted(merged.coords) == ["band", "spatial_ref", "x", "y"]
     assert merged.rio.crs == rds.rio.crs
+    assert_almost_equal(merged.attrs.pop("_FillValue"), rds.attrs.pop("_FillValue"))
     assert merged.attrs == rds.attrs
     assert_almost_equal(nansum(merged), 13556564)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #162
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API


This ensures the proper dtype is used for the nodata value when:
1. Reading the nodata value.
2. Writing the notata value.
3. Writing the nodata value to a raster (partially related to #113).

A warning message is added if the value changes when the dtype is converted.