### PR TITLE
BUG: Allow 'rio.write_crs' when spatial dimensions not found

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Latest
 ------
 - ENH: Added `rio.estimate_utm_crs` (issue #181)
 - ENH: Add support for merging datasets with different CRS (issue #173)
+- BUG: Allow `rio.write_crs` when spatial dimensions not found (pull #186)
 
 0.1.1
 ------

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1590,6 +1590,17 @@ def test_write_crs_cf():
     assert test_da.spatial_ref.attrs["grid_mapping_name"] == "latitude_longitude"
 
 
+def test_write_crs__missing_geospatial_dims():
+    test_da = xarray.DataArray(
+        [1],
+        name="data",
+        dims=("time",),
+        coords={"time": [1]},
+    )
+    assert test_da.copy().rio.write_crs(3857).rio.crs.to_epsg() == 3857
+    assert test_da.to_dataset().rio.write_crs(3857).rio.crs.to_epsg() == 3857
+
+
 def test_read_crs_cf():
     test_da = xarray.DataArray(1)
     test_da = test_da.rio.write_crs(4326)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Discovered the issue here: https://github.com/corteva/geocube/pull/43

 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
