### PR TITLE
BUG: Update merge to support rasterio 1.2+

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Latest
 - ENH: Add support for merging datasets with different CRS (issue #173)
 - ENH: Add support for using dask in `rio.to_raster` (issue #9)
 - BUG: Allow `rio.write_crs` when spatial dimensions not found (pull #186)
+- BUG: Update to support rasterio 1.2+ merge (issue #180)
 
 0.1.1
 ------

--- a/rioxarray/merge.py
+++ b/rioxarray/merge.py
@@ -32,6 +32,22 @@ class RasterioDatasetDuck:
         res = xds.rio.resolution(recalc=True)
         self.res = (abs(res[0]), abs(res[1]))
         self.transform = xds.rio.transform(recalc=True)
+        try:
+            rio_file = xds._file_obj.acquire()
+            self.profile = rio_file.profile
+            self.colormap = rio_file.colormap
+        except AttributeError:
+            self.profile = {}
+
+            def colormap(_):
+                return None
+
+            self.colormap = colormap
+        self.profile.update(
+            dtype=xds.dtype,
+            crs=xds.rio.crs,
+            nodata=xds.rio.nodata,
+        )
 
     def read(self, window, out_shape, *args, **kwargs) -> numpy.ma.array:
         # pylint: disable=unused-argument


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Related to #180, https://github.com/mapbox/rasterio/pull/1994
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

Currently broken with 1.2.