### PR TITLE
ENH: Add 'compute' keyword argument to 'to_raster'

### DIFF
--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -851,7 +851,7 @@ class RasterArray(XRasterBase):
         lock: boolean or Lock, optional
             Lock to use to write data using dask.
             If not supplied, it will use a single process for writing.
-        compute: bool
+        compute: bool, optional
             If True and data is a dask array, then compute and save
             the data immediately. If False, return a dask Delayed object.
             Call ".compute()" on the Delayed object to compute the result

--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -865,7 +865,7 @@ class RasterArray(XRasterBase):
         Returns
         -------
         :obj:`dask.Delayed`:
-            If the data array is a dask array, windowed is True, and compute
+            If the data array is a dask array and compute
             is True. Otherwise None is returned.
 
         """

--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -852,12 +852,11 @@ class RasterArray(XRasterBase):
             Lock to use to write data using dask.
             If not supplied, it will use a single process for writing.
         compute: bool
-            If True and the data array is a dask array and windowed
-            is True, then compute and save the data immediately. If False,
-            return a dask Delayed object. Call ".compute()" on the Delayed
-            object to compute the result later. Call
-            ``dask.compute(delayed1, delayed2)`` to save multiple delayed
-            files at once. Default is True.
+            If True and data is a dask array, then compute and save
+            the data immediately. If False, return a dask Delayed object.
+            Call ".compute()" on the Delayed object to compute the result
+            later. Call ``dask.compute(delayed1, delayed2)`` to save
+            multiple delayed files at once. Default is True.
         **profile_kwargs
             Additional keyword arguments to pass into writing the raster. The
             nodata, transform, crs, count, width, and height attributes

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -362,12 +362,11 @@ class RasterDataset(XRasterBase):
             Lock to use to write data using dask.
             If not supplied, it will use a single process for writing.
         compute: bool
-            If True and the data array is a dask array and windowed
-            is True, then compute and save the data immediately. If False,
-            return a dask Delayed object. Call ".compute()" on the Delayed
-            object to compute the result later. Call
-            ``dask.compute(delayed1, delayed2)`` to save multiple delayed
-            files at once. Default is True.
+            If True and data is a dask array, then compute and save
+            the data immediately. If False, return a dask Delayed object.
+            Call ".compute()" on the Delayed object to compute the result
+            later. Call ``dask.compute(delayed1, delayed2)`` to save
+            multiple delayed files at once. Default is True.
         **profile_kwargs
             Additional keyword arguments to pass into writing the raster. The
             nodata, transform, crs, count, width, and height attributes

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -375,7 +375,7 @@ class RasterDataset(XRasterBase):
         Returns
         -------
         :obj:`dask.Delayed`:
-            If the data array is a dask array, windowed is True, and compute
+            If the data array is a dask array and compute
             is True. Otherwise None is returned.
 
         """

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -361,7 +361,7 @@ class RasterDataset(XRasterBase):
         lock: boolean or Lock, optional
             Lock to use to write data using dask.
             If not supplied, it will use a single process for writing.
-        compute: bool
+        compute: bool, optional
             If True and data is a dask array, then compute and save
             the data immediately. If False, return a dask Delayed object.
             Call ".compute()" on the Delayed object to compute the result

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -334,6 +334,7 @@ class RasterDataset(XRasterBase):
         windowed=False,
         recalc_transform=True,
         lock=None,
+        compute=True,
         **profile_kwargs,
     ):
         """
@@ -360,10 +361,23 @@ class RasterDataset(XRasterBase):
         lock: boolean or Lock, optional
             Lock to use to write data using dask.
             If not supplied, it will use a single process for writing.
+        compute: bool
+            If True and the data array is a dask array and windowed
+            is True, then compute and save the data immediately. If False,
+            return a dask Delayed object. Call ".compute()" on the Delayed
+            object to compute the result later. Call
+            ``dask.compute(delayed1, delayed2)`` to save multiple delayed
+            files at once. Default is True.
         **profile_kwargs
             Additional keyword arguments to pass into writing the raster. The
             nodata, transform, crs, count, width, and height attributes
             are ignored.
+
+        Returns
+        -------
+        :obj:`dask.Delayed`:
+            If the data array is a dask array, windowed is True, and compute
+            is True. Otherwise None is returned.
 
         """
         variable_dim = "band_{}".format(uuid4())
@@ -394,7 +408,7 @@ class RasterDataset(XRasterBase):
         if self.crs is not None:
             data_array.rio.write_crs(self.crs, inplace=True)
         # write it to a raster
-        data_array.rio.to_raster(
+        return data_array.rio.to_raster(
             raster_path=raster_path,
             driver=driver,
             dtype=dtype,
@@ -402,5 +416,6 @@ class RasterDataset(XRasterBase):
             windowed=windowed,
             recalc_transform=recalc_transform,
             lock=lock,
+            compute=compute,
             **profile_kwargs,
         )

--- a/rioxarray/raster_writer.py
+++ b/rioxarray/raster_writer.py
@@ -139,12 +139,11 @@ class RasterioWriter:
             Lock to use to write data using dask.
             If not supplied, it will use a single process.
         compute: bool
-            If True (default) and the data array is a dask array and windowed
-            is True, then compute and save the data immediately. If False,
-            return a dask Delayed object. Call ".compute()" on the Delayed
-            object to compute the result later. Call
-            ``dask.compute(delayed1, delayed2)`` to save multiple delayed
-            files at once.
+            If True (default) and data is a dask array, then compute and save
+            the data immediately. If False, return a dask Delayed object.
+            Call ".compute()" on the Delayed object to compute the result
+            later. Call ``dask.compute(delayed1, delayed2)`` to save
+            multiple delayed files at once.
         **kwargs
             Keyword arguments to pass into writing the raster.
         """

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1038,9 +1038,11 @@ def test_geographic_resample_integer():
         xarray.open_dataarray,
         partial(rioxarray.open_rasterio, masked=True),
         partial(rioxarray.open_rasterio, masked=True, chunks=True),
-        partial(rioxarray.open_rasterio, masked=True, chunks=True,
-                lock=threading.Lock())
-        ])
+        partial(
+            rioxarray.open_rasterio, masked=True, chunks=True, lock=threading.Lock()
+        ),
+    ],
+)
 @pytest.mark.parametrize(
     "windowed, recalc_transform",
     [
@@ -1054,9 +1056,11 @@ def test_geographic_resample_integer():
         (None, False),
         (threading.Lock(), False),
         (threading.Lock(), True),
-    ]
+    ],
 )
-def test_to_raster(open_method, windowed, recalc_transform, write_lock, compute, tmpdir):
+def test_to_raster(
+    open_method, windowed, recalc_transform, write_lock, compute, tmpdir
+):
     tmp_raster = tmpdir.join("modis_raster.tif")
     test_tags = {"test": "1"}
     with open_method(os.path.join(TEST_INPUT_DATA_DIR, "MODIS_ARRAY.nc")) as mda:


### PR DESCRIPTION
See #211 for additional context. The summary is that dask's `store` function allows you to pass `compute=False`. Doing this returns a `Delayed` object which can be computed later. This is really useful if your input dask arrays are used in other outputs (very common in the Satpy library where one input raster may be used for different RGB channels in various composites).

At the time of writing this only implements the functionality and includes some docstrings. Some questions and issues I ran into that I'm looking for help on:

1. Where would you like tests added for this? I could add more parametrize cases to `test_to_raster` in `test_integration_rioxarray`.
2. This, as I feared in #211, doesn't seem to work on a distributed client (multiprocess). But this doesn't actually seem to work with the existing behavior (compute=True). See below.
3. Other feedback?

## Distributed Issues

Example:

```
import rioxarray
import dask.diagnostics
import dask.distributed

g = rioxarray.open_rasterio("any_geotiff.tif", chunks=1024)
client = dask.distributed.Client()
with dask.diagnostics.ProgressBar():
    delayed = g.rio.to_raster("/tmp/some_out.tif", windowed=True)

# or
with dask.diagnostics.ProgressBar():
    delayed = g.rio.to_raster("/tmp/some_out.tif", windowed=True, compute=False)
with dask.diagnostics.ProgressBar():
    delayed.compute()
```


```
~/miniconda3/envs/satpy_py37/lib/python3.7/site-packages/dask/array/core.py in load_store_chunk()
   3711     try:
   3712         if x is not None:
-> 3713             out[index] = np.asanyarray(x)
   3714         if return_stored and load_stored:
   3715             result = out[index]

~/repos/git/rioxarray/rioxarray/raster_writer.py in __setitem__()
    121
    122         with rasterio.open(self.raster_path, "r+") as rds:
--> 123             rds.write(item, window=Window(chx_off, chy_off, chx, chy), indexes=indexes)
    124
    125     def to_raster(self, xarray_dataarray, tags, windowed, compute, **kwargs):

rasterio/_io.pyx in rasterio._io.DatasetWriterBase.write()

RasterioIOError: Read or write failed. /tmp/c07.tif, band 1: IReadBlock failed at X offset 0, Y offset 1108: TIFFReadEncodedStrip() failed.
```

Ideas?

## Checklist

 - [ ] Closes #211
 - [ ] Tests added
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
