### PR TITLE
BUG: Raise informative error in interpolate_na if missing nodata

### DIFF
--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -789,6 +789,12 @@ class RasterArray(XRasterBase):
         :obj:`xarray.DataArray`:
             An interpolated :obj:`xarray.DataArray` object.
         """
+        if self.nodata is None:
+            raise RioXarrayError(
+                "nodata not found. Please set the nodata with 'rio.write_nodata()'."
+                f"{_get_data_var_message(self._obj)}"
+            )
+
         extra_dim = self._check_dimensions()
         if extra_dim:
             interp_data = []

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -2290,3 +2290,20 @@ def test_estimate_utm_crs__out_of_bounds():
     else:
         with pytest.raises(RuntimeError, match=r"Unable to determine UTM CRS"):
             xds.rio.estimate_utm_crs()
+
+
+def test_interpolate_na_missing_nodata():
+    test_da = xarray.DataArray(
+        name="missing",
+        data=numpy.zeros((5, 5)),
+        dims=("y", "x"),
+        coords={"y": numpy.arange(1, 6), "x": numpy.arange(2, 7)},
+    )
+    match = (
+        r"nodata not found\. Please set the nodata with "
+        r"'rio\.write_nodata\(\)'\. Data variable: missing"
+    )
+    with pytest.raises(RioXarrayError, match=match):
+        test_da.rio.interpolate_na()
+    with pytest.raises(RioXarrayError, match=match):
+        test_da.to_dataset().rio.interpolate_na()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #250
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
