### PR TITLE
Fix upstream build by pointing to the `main` branch for dask

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,8 +108,8 @@ jobs:
           #   pandas \
           #   scipy;
           python -m pip install --upgrade \
-            git+https://github.com/dask/dask.git@master \
-            git+https://github.com/dask/distributed.git@master \
+            git+https://github.com/dask/dask.git@main \
+            git+https://github.com/dask/distributed.git@main \
             git+https://github.com/mapbox/rasterio.git@master \
             git+https://github.com/pyproj4/pyproj.git@master \
             git+https://github.com/pydata/xarray.git@master;


### PR DESCRIPTION
Trivial fix for the rename to `main` in dask repos