### PR TITLE
BUG: Return correct transform in rio.transform with non-linear transform

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Latest
 - DEP: xarray 0.17+ (needed for issue #282)
 - REF: Store `grid_mapping` in `encoding` instead of `attrs` (issue #282)
 - ENH: enable `engine="rasterio"` via xarray backend API (issue #197 pull #281)
+- BUG: Return correct transform in `rio.transform` with non-linear transform (discussions #280)
 
 0.3.2
 -----

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -3,6 +3,7 @@ This module is an extension for xarray to provide rasterio capabilities
 to xarray datasets/dataarrays.
 """
 import math
+import warnings
 
 import numpy as np
 import pyproj
@@ -492,6 +493,12 @@ class XRasterBase:
         :obj:`affine.Afffine`:
             The affine of the :obj:`xarray.Dataset` | :obj:`xarray.DataArray`
         """
+        transform = self._cached_transform()
+        if transform and not transform.is_rectilinear:
+            if recalc:
+                warnings.warn("Non-rectilinear transform found. Unable to recalculate.")
+            return transform
+
         try:
             src_left, _, _, src_top = self.bounds(recalc=recalc)
             src_resolution_x, src_resolution_y = self.resolution(recalc=recalc)

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -2120,6 +2120,34 @@ def test_write_transform():
     assert da.rio.grid_mapping == "spatial_ref"
 
 
+def test_write_read_transform__non_rectilinear():
+    test_affine = Affine.from_gdal(305827, 14, 9, 5223236, 9, -14)
+    ds = xarray.Dataset()
+    ds.rio.write_transform(test_affine, inplace=True)
+    assert ds.spatial_ref.GeoTransform == "305827.0 14.0 9.0 5223236.0 9.0 -14.0"
+    assert ds.rio._cached_transform() == test_affine
+    assert ds.rio.transform() == test_affine
+    assert ds.rio.grid_mapping == "spatial_ref"
+    da = xarray.DataArray(1)
+    da.rio.write_transform(test_affine, inplace=True)
+    assert ds.rio._cached_transform() == test_affine
+    assert ds.rio.transform() == test_affine
+    assert da.spatial_ref.GeoTransform == "305827.0 14.0 9.0 5223236.0 9.0 -14.0"
+    assert da.rio.grid_mapping == "spatial_ref"
+
+
+def test_write_read_transform__non_rectilinear__warning():
+    test_affine = Affine.from_gdal(305827, 14, 9, 5223236, 9, -14)
+    ds = xarray.Dataset()
+    ds.rio.write_transform(test_affine, inplace=True)
+    with pytest.warns(UserWarning, match=r"Non\-rectilinear transform found"):
+        assert ds.rio.transform(recalc=True) == test_affine
+    da = xarray.DataArray(1)
+    da.rio.write_transform(test_affine, inplace=True)
+    with pytest.warns(UserWarning, match=r"Non\-rectilinear transform found"):
+        assert ds.rio.transform(recalc=True) == test_affine
+
+
 def test_missing_transform():
     ds = xarray.Dataset()
     assert ds.rio.transform() == Affine.identity()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Related to discussion #280

 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
