### PR TITLE
TST: Add more tests for rasterio engine

### DIFF
--- a/rioxarray/xarray_plugin.py
+++ b/rioxarray/xarray_plugin.py
@@ -3,6 +3,7 @@ import os.path
 import xarray as xr
 
 from . import _io
+from .exceptions import RioXarrayError
 
 CAN_OPEN_EXTS = {
     "asc",
@@ -28,11 +29,13 @@ class RasterioBackend(xr.backends.common.BackendEntrypoint):
     def open_dataset(
         self,
         filename_or_obj,
-        drop_variables=None,
-        mask_and_scale=True,
+        drop_variables=None,  # SKIP FROM XARRAY
         parse_coordinates=None,
+        chunks=None,
+        cache=None,
         lock=None,
         masked=False,
+        mask_and_scale=True,
         variable=None,
         group=None,
         default_name="band_data",
@@ -53,6 +56,11 @@ class RasterioBackend(xr.backends.common.BackendEntrypoint):
         )
         if isinstance(ds, xr.DataArray):
             ds = ds.to_dataset()
+        if not isinstance(ds, xr.Dataset):
+            raise RioXarrayError(
+                "Multiple resolution sets found. "
+                "Use 'variable' or 'group' to filter."
+            )
         return ds
 
     def guess_can_open(self, filename_or_obj):

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -747,7 +747,9 @@ def test_no_mftime():
                 assert_allclose(actual, expected)
 
 
-@pytest.mark.xfail(reason="Network could be problematic")
+@pytest.mark.xfail(
+    error=rasterio.errors.RasterioIOError, reason="Network could be problematic"
+)
 def test_http_url():
     # more examples urls here
     # http://download.osgeo.org/geotiff/samples/

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -753,9 +753,12 @@ def test_no_mftime():
 def test_http_url():
     # more examples urls here
     # http://download.osgeo.org/geotiff/samples/
-    url = "http://download.osgeo.org/geotiff/samples/made_up/ntf_nord.tif"
+    url = (
+        "https://github.com/corteva/rioxarray/blob/master/"
+        "test/test_data/input/cog.tif?raw=true"
+    )
     with rioxarray.open_rasterio(url) as actual:
-        assert actual.shape == (1, 512, 512)
+        assert actual.shape == (1, 500, 500)
     # make sure chunking works
     with rioxarray.open_rasterio(url, chunks=(1, 256, 256)) as actual:
         assert isinstance(actual.data, dask.array.Array)

--- a/test/integration/test_integration_xarray_plugin.py
+++ b/test/integration/test_integration_xarray_plugin.py
@@ -2,6 +2,7 @@ import os.path
 
 import pytest
 
+from rioxarray.exceptions import RioXarrayError
 from test.conftest import TEST_INPUT_DATA_DIR
 
 # FIXME: change to the next xarray version after release
@@ -24,3 +25,16 @@ def test_xarray_open_dataset():
     ds = xr.open_dataset(cog_file)
 
     assert isinstance(ds, xr.Dataset)
+
+
+def test_open_multiple_resolution():
+    with pytest.raises(
+        RioXarrayError,
+        match="Multiple resolution sets found. Use 'variable' or 'group' to filter.",
+    ):
+        xr.open_dataset(
+            os.path.join(
+                TEST_INPUT_DATA_DIR, "MOD09GA.A2008296.h14v17.006.2015181011753.hdf"
+            ),
+            engine="rasterio",
+        )


### PR DESCRIPTION
Continuation of #281 

In the process of doing this:
1. I noticed `xarray.open_rasterio` was being tested instead of `rioxarray.open_rasterio`, so I updated that.
2. Added fix for missing arguments in the engine.