### PR TITLE
BUG: Don't generate x,y coords in 'rio' methods if not previously there

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -10,6 +10,7 @@ Latest
 - ENH: Generate 2D coordinates for non-rectilinear sources (issue #290)
 - BUG: Return correct transform in `rio.transform` with non-rectilinear transform (discussions #280)
 - BUG: Update to handle WindowError in rasterio 1.2.2 (issue #286)
+- BUG: Don't generate x,y coords in `rio` methods if not previously there (pull #294)
 
 0.3.2
 -----

--- a/rioxarray/merge.py
+++ b/rioxarray/merge.py
@@ -264,6 +264,7 @@ def merge_datasets(
             merged_data[data_var].rio.transform(),
             merged_data[data_var].shape[-1],
             merged_data[data_var].shape[-2],
+            force_generate=True,
         ),
         attrs=representative_ds.attrs,
     )

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -100,12 +100,19 @@ def _get_nonspatial_coords(src_data_array):
     return coords
 
 
-def _make_coords(src_data_array, dst_affine, dst_width, dst_height):
+def _make_coords(
+    src_data_array, dst_affine, dst_width, dst_height, force_generate=False
+):
     """Generate the coordinates of the new projected `xarray.DataArray`"""
     coords = _get_nonspatial_coords(src_data_array)
-    new_coords = _generate_spatial_coords(dst_affine, dst_width, dst_height)
-    new_coords.update(coords)
-    return new_coords
+    if force_generate or (
+        src_data_array.rio.x_dim in src_data_array.coords
+        and src_data_array.rio.y_dim in src_data_array.coords
+    ):
+        new_coords = _generate_spatial_coords(dst_affine, dst_width, dst_height)
+        new_coords.update(coords)
+        return new_coords
+    return coords
 
 
 def _get_data_var_message(obj):

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -576,7 +576,7 @@ def test_reproject(modis_reproject):
     "open_func",
     [
         rioxarray.open_rasterio,
-        # partial(rioxarray.open_rasterio, parse_coordinates=False), TODO: Fix
+        partial(rioxarray.open_rasterio, parse_coordinates=False),
     ],
 )
 def test_reproject_3d(open_func, modis_reproject_3d):
@@ -586,18 +586,19 @@ def test_reproject_3d(open_func, modis_reproject_3d):
         mds_repr = mda.rio.reproject(modis_reproject_3d["to_proj"])
         # test
         _assert_xarrays_equal(mds_repr, mdc)
-        assert mds_repr.coords[mds_repr.rio.x_dim].attrs == {
-            "long_name": "longitude",
-            "standard_name": "longitude",
-            "units": "degrees_east",
-            "axis": "X",
-        }
-        assert mds_repr.coords[mds_repr.rio.y_dim].attrs == {
-            "long_name": "latitude",
-            "standard_name": "latitude",
-            "units": "degrees_north",
-            "axis": "Y",
-        }
+        if mdc.rio.x_dim in mdc.coords:
+            assert mds_repr.coords[mds_repr.rio.x_dim].attrs == {
+                "long_name": "longitude",
+                "standard_name": "longitude",
+                "units": "degrees_east",
+                "axis": "X",
+            }
+            assert mds_repr.coords[mds_repr.rio.y_dim].attrs == {
+                "long_name": "latitude",
+                "standard_name": "latitude",
+                "units": "degrees_north",
+                "axis": "Y",
+            }
 
 
 def test_reproject__grid_mapping(modis_reproject):
@@ -725,18 +726,19 @@ def test_reproject_match(modis_reproject_match):
         mds_repr = mda.rio.reproject_match(mdm)
         # test
         _assert_xarrays_equal(mds_repr, mdc)
-        assert mds_repr.coords[mds_repr.rio.x_dim].attrs == {
-            "axis": "X",
-            "long_name": "x coordinate of projection",
-            "standard_name": "projection_x_coordinate",
-            "units": "metre",
-        }
-        assert mds_repr.coords[mds_repr.rio.y_dim].attrs == {
-            "axis": "Y",
-            "long_name": "y coordinate of projection",
-            "standard_name": "projection_y_coordinate",
-            "units": "metre",
-        }
+        if mdc.rio.x_dim in mdc.coords:
+            assert mds_repr.coords[mds_repr.rio.x_dim].attrs == {
+                "axis": "X",
+                "long_name": "x coordinate of projection",
+                "standard_name": "projection_x_coordinate",
+                "units": "metre",
+            }
+            assert mds_repr.coords[mds_repr.rio.y_dim].attrs == {
+                "axis": "Y",
+                "long_name": "y coordinate of projection",
+                "standard_name": "projection_y_coordinate",
+                "units": "metre",
+            }
 
 
 def test_reproject_match__masked(modis_reproject_match):


### PR DESCRIPTION
Discovered FIXME in docstring while working on #293.