### PR TITLE
ENH: Add support for 'drop_variables' in rasterio engine

### DIFF
--- a/rioxarray/xarray_plugin.py
+++ b/rioxarray/xarray_plugin.py
@@ -23,13 +23,15 @@ CAN_OPEN_EXTS = {
 
 class RasterioBackend(xr.backends.common.BackendEntrypoint):
     """
+    Requires xarray 0.18+
+
     .. versionadded:: 0.4
     """
 
     def open_dataset(
         self,
         filename_or_obj,
-        drop_variables=None,  # SKIP FROM XARRAY
+        drop_variables=None,
         parse_coordinates=None,
         chunks=None,
         cache=None,
@@ -45,10 +47,12 @@ class RasterioBackend(xr.backends.common.BackendEntrypoint):
             open_kwargs = {}
         ds = _io.open_rasterio(
             filename_or_obj,
-            mask_and_scale=mask_and_scale,
             parse_coordinates=parse_coordinates,
+            chunks=chunks,
+            cache=cache,
             lock=lock,
             masked=masked,
+            mask_and_scale=mask_and_scale,
             variable=variable,
             group=group,
             default_name=default_name,
@@ -56,6 +60,8 @@ class RasterioBackend(xr.backends.common.BackendEntrypoint):
         )
         if isinstance(ds, xr.DataArray):
             ds = ds.to_dataset()
+        if drop_variables is not None:
+            ds = ds.drop_vars(drop_variables)
         if not isinstance(ds, xr.Dataset):
             raise RioXarrayError(
                 "Multiple resolution sets found. "

--- a/test/integration/test_integration_xarray_plugin.py
+++ b/test/integration/test_integration_xarray_plugin.py
@@ -27,6 +27,34 @@ def test_xarray_open_dataset():
     assert isinstance(ds, xr.Dataset)
 
 
+def test_xarray_open_dataset__drop_variables():
+    input_file = os.path.join(
+        TEST_INPUT_DATA_DIR, "MOD09GA.A2008296.h14v17.006.2015181011753.hdf"
+    )
+
+    rds = xr.open_dataset(
+        input_file,
+        engine="rasterio",
+        group="MODIS_Grid_500m_2D",
+        drop_variables=[
+            "sur_refl_b01_1",
+            "sur_refl_b02_1",
+            "sur_refl_b03_1",
+            "sur_refl_b04_1",
+            "sur_refl_b05_1",
+            "sur_refl_b06_1",
+            "sur_refl_b07_1",
+        ],
+    )
+
+    assert sorted(rds.data_vars) == [
+        "QC_500m_1",
+        "iobs_res_1",
+        "num_observations_500m",
+        "obscov_500m_1",
+    ]
+
+
 def test_open_multiple_resolution():
     with pytest.raises(
         RioXarrayError,


### PR DESCRIPTION
Figured either supporting it or rasing an error would be best since it is passed into this method. Doing nothing silently would be bad.