### PR TITLE
BUG: Use float32 for smaller dtypes when masking

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Latest
 - REF: Store `grid_mapping` in `encoding` instead of `attrs` (issue #282)
 - ENH: enable `engine="rasterio"` via xarray backend API (issue #197 pull #281)
 - ENH: Generate 2D coordinates for non-rectilinear sources (issue #290)
+- BUG: Use float32 for smaller dtypes when masking (discussions #302)
 - BUG: Return correct transform in `rio.transform` with non-rectilinear transform (discussions #280)
 - BUG: Update to handle WindowError in rasterio 1.2.2 (issue #286)
 - BUG: Don't generate x,y coords in `rio` methods if not previously there (pull #294)

--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -22,6 +22,7 @@ import xarray
 from rasterio.enums import Resampling
 from rasterio.features import geometry_mask
 from scipy.interpolate import griddata
+from xarray.core.dtypes import get_fill_value
 
 from rioxarray.crs import crs_from_user_input
 from rioxarray.exceptions import (
@@ -264,7 +265,7 @@ class RasterArray(XRasterBase):
             return None if self._nodata is False else self._nodata
 
         if self.encoded_nodata is not None:
-            self._nodata = np.nan
+            self._nodata = get_fill_value(self._obj.dtype)
         else:
             self._nodata = self._obj.attrs.get(
                 "_FillValue",

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -263,8 +263,8 @@ def test_open_rasterio_mask_chunk_clip():
         if isinstance(xdi, xr.Dataset):
             xdi = xdi.dem
         assert xdi.name == "dem"
-        assert str(xdi.dtype) == "float64"
-        assert str(xdi.data.dtype) == "float64"
+        assert str(xdi.dtype) == "float32"
+        assert str(xdi.data.dtype) == "float32"
         assert str(type(xdi.data)) == "<class 'dask.array.core.Array'>"
         assert xdi.chunks == ((1,), (245,), (574,))
         assert np.isnan(xdi.values).sum() == 52119
@@ -868,8 +868,8 @@ def test_mask_and_scale(open_rasterio):
     test_file = os.path.join(TEST_INPUT_DATA_DIR, "tmmx_20190121.nc")
     with pytest.warns(SerializationWarning):
         with open_rasterio(test_file, mask_and_scale=True) as rds:
-            assert np.nanmin(rds.air_temperature.values) == 248.7
-            assert np.nanmax(rds.air_temperature.values) == 302.1
+            assert np.nanmin(rds.air_temperature.values) == np.float32(248.7)
+            assert np.nanmax(rds.air_temperature.values) == np.float32(302.1)
             test_encoding = dict(rds.air_temperature.encoding)
             source = test_encoding.pop("source")
             assert source.startswith("netcdf:") and source.endswith(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Related to #302
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
