### PR TITLE
DOC: Include resampling methods in reproject_match documentation 

### DIFF
--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -357,7 +357,21 @@ class RasterArray(XRasterBase):
         transform: optional
             The destination transform.
         resampling: Resampling method, optional
-            See rasterio.warp.reproject for more details.
+            0: Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
+            1: Bilinear resampling.
+            2: Cubic resampling.
+            3: Cubic spline resampling.
+            4: Lanczos windowed sinc resampling.
+            5: Average resampling, computes the weighted average of all non-NODATA contributing pixels.
+            6: Mode resampling, selects the value which appears most often of all the sampled points.
+            8: Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+            9: Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+            10: Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            11: Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            12: Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            13: Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.3)
+            14: RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
+            Method 7 (gauss), not available. See rasterio.warp.reproject for more details.
 
 
         Returns
@@ -451,7 +465,21 @@ class RasterArray(XRasterBase):
         match_data_array:  :obj:`xarray.DataArray` | :obj:`xarray.Dataset`
             DataArray of the target resolution and projection.
         resampling: Resampling method, optional
-            See rasterio.warp.reproject for more details.
+            0: Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
+            1: Bilinear resampling.
+            2: Cubic resampling.
+            3: Cubic spline resampling.
+            4: Lanczos windowed sinc resampling.
+            5: Average resampling, computes the weighted average of all non-NODATA contributing pixels.
+            6: Mode resampling, selects the value which appears most often of all the sampled points.
+            8: Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+            9: Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+            10: Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            11: Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            12: Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            13: Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.3)
+            14: RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
+            Method 7 (gauss), not available. See rasterio.warp.reproject for more details.
 
 
         Returns

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -82,8 +82,22 @@ class RasterDataset(XRasterBase):
             together with resolution.
         transform: optional
             The destination transform.
-        resampling: Resampling method, optional
-            See rasterio.warp.reproject for more details.
+        resampling: Resampling method, optional. One of the following:
+            0: Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
+            1: Bilinear resampling.
+            2: Cubic resampling.
+            3: Cubic spline resampling.
+            4: Lanczos windowed sinc resampling.
+            5: Average resampling, computes the weighted average of all non-NODATA contributing pixels.
+            6: Mode resampling, selects the value which appears most often of all the sampled points.
+            8: Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+            9: Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+            10: Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            11: Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            12: Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            13: Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.3)
+            14: RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
+            Method 7 (gauss), not available. See rasterio.warp.reproject for more details.
 
 
         Returns
@@ -122,7 +136,21 @@ class RasterDataset(XRasterBase):
         match_data_array: :obj:`xarray.DataArray` | :obj:`xarray.Dataset`
             Dataset with the target resolution and projection.
         resampling: Resampling method, optional
-            See rasterio.warp.reproject for more details.
+            0: Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
+            1: Bilinear resampling.
+            2: Cubic resampling.
+            3: Cubic spline resampling.
+            4: Lanczos windowed sinc resampling.
+            5: Average resampling, computes the weighted average of all non-NODATA contributing pixels.
+            6: Mode resampling, selects the value which appears most often of all the sampled points.
+            8: Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+            9: Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+            10: Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            11: Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            12: Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+            13: Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.3)
+            14: RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
+            Method 7 (gauss), not available. See rasterio.warp.reproject for more details.
 
 
         Returns


### PR DESCRIPTION
Include resampling method enumeration in reproject_match documentation

The current documentation for reproject_match() for [Datasets](https://spestana.github.io/rioxarray/stable/rioxarray.html?highlight=reproject_match#rioxarray.raster_dataset.RasterDataset.reproject_match) and [DataArrays ](https://spestana.github.io/rioxarray/stable/rioxarray.html?highlight=reproject_match#rioxarray.raster_array.RasterArray.reproject_match) doesn't include the full list of resampling methods and their rasterio.reproject.warp enumerations, nor a link to the rasterio documentation.

I think a full list should be included here in the rioxarray documentation.

Rasterio lists the methods in [rasterio.reproject.warp documentation here](https://rasterio.readthedocs.io/en/latest/api/rasterio.warp.html#rasterio.warp.reproject) but you have to search elsewhere, [in the enumerations here](https://rasterio.readthedocs.io/en/latest/api/rasterio.enums.html?highlight=Resampleing.nearest#rasterio.enums.Resampling) to find the integer values to use for the different methods. A short description of each method such as from [gdalwarp here](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r) would also be helpful.