### PR TITLE
ENH: Added 'decode_times' and 'decode_timedelta' kwargs to 'rioxarray.open_rasterio'

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,7 @@ Latest
 - ENH: enable `engine="rasterio"` via xarray backend API (issue #197 pull #281)
 - ENH: Generate 2D coordinates for non-rectilinear sources (issue #290)
 - ENH: Add `encoded` kwarg to `rio.write_nodata` (discussions #313)
+- ENH: Added `decode_times` and `decode_timedelta` kwargs to `rioxarray.open_rasterio` (issue #316)
 - BUG: Use float32 for smaller dtypes when masking (discussions #302)
 - BUG: Return correct transform in `rio.transform` with non-rectilinear transform (discussions #280)
 - BUG: Update to handle WindowError in rasterio 1.2.2 (issue #286)

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -26,6 +26,7 @@ from xarray.core import indexing
 from xarray.core.dataarray import DataArray
 from xarray.core.dtypes import maybe_promote
 from xarray.core.utils import is_scalar
+from xarray.core.variable import as_variable
 
 from rioxarray.exceptions import RioXarrayError
 from rioxarray.rioxarray import _generate_spatial_coords
@@ -452,60 +453,37 @@ def _get_rasterio_attrs(riods):
     return attrs
 
 
-def _decode_datetime_cf(data_array):
+def _decode_datetime_cf(data_array, decode_times, decode_timedelta):
     """
     Decide the datetime based on CF conventions
     """
-    for coord in data_array.coords:
-        # stage 1: timedelta
-        if (
-            "units" in data_array[coord].attrs
-            and data_array[coord].attrs["units"] in times.TIME_UNITS
-        ):
-            units = times.pop_to(
-                data_array[coord].attrs, data_array[coord].encoding, "units"
-            )
-            new_values = times.decode_cf_timedelta(
-                data_array[coord].values, units=units
-            )
-            data_array = data_array.assign_coords(
-                {
-                    coord: IndexVariable(
-                        dims=data_array[coord].dims,
-                        data=new_values.astype(np.dtype("timedelta64[ns]")),
-                        attrs=data_array[coord].attrs,
-                        encoding=data_array[coord].encoding,
-                    )
-                }
-            )
+    if decode_timedelta is None:
+        decode_timedelta = decode_times
 
-        # stage 2: datetime
-        if (
-            "units" in data_array[coord].attrs
-            and "since" in data_array[coord].attrs["units"]
+    for coord in data_array.coords:
+        time_var = None
+        if decode_times and "since" in data_array[coord].attrs.get("units", ""):
+            time_var = times.CFDatetimeCoder(use_cftime=True).decode(
+                as_variable(data_array[coord]), name=coord
+            )
+        elif (
+            decode_timedelta
+            and data_array[coord].attrs.get("units") in times.TIME_UNITS
         ):
-            units = times.pop_to(
-                data_array[coord].attrs, data_array[coord].encoding, "units"
+            time_var = times.CFTimedeltaCoder().decode(
+                as_variable(data_array[coord]), name=coord
             )
-            calendar = times.pop_to(
-                data_array[coord].attrs, data_array[coord].encoding, "calendar"
-            )
-            dtype = times._decode_cf_datetime_dtype(
-                data_array[coord].values, units, calendar, True
-            )
-            new_values = times.decode_cf_datetime(
-                data_array[coord].values,
-                units=units,
-                calendar=calendar,
-                use_cftime=True,
+        if time_var is not None:
+            dimensions, data, attributes, encoding = variables.unpack_for_decoding(
+                time_var
             )
             data_array = data_array.assign_coords(
                 {
                     coord: IndexVariable(
-                        dims=data_array[coord].dims,
-                        data=new_values.astype(dtype),
-                        attrs=data_array[coord].attrs,
-                        encoding=data_array[coord].encoding,
+                        dims=dimensions,
+                        data=data,
+                        attrs=attributes,
+                        encoding=encoding,
                     )
                 }
             )
@@ -539,6 +517,9 @@ def _load_subdatasets(
     lock,
     masked,
     mask_and_scale,
+    decode_times,
+    decode_timedelta,
+    **open_kwargs,
 ):
     """
     Load in rasterio subdatasets
@@ -562,6 +543,9 @@ def _load_subdatasets(
             masked=masked,
             mask_and_scale=mask_and_scale,
             default_name=subdataset.split(":")[-1].lstrip("/").replace("/", "_"),
+            decode_times=decode_times,
+            decode_timedelta=decode_timedelta,
+            **open_kwargs,
         )
         if shape not in dim_groups:
             dim_groups[shape] = {rioda.name: rioda}
@@ -648,6 +632,8 @@ def open_rasterio(
     variable=None,
     group=None,
     default_name=None,
+    decode_times=True,
+    decode_timedelta=None,
     **open_kwargs,
 ):
     # pylint: disable=too-many-statements,too-many-locals,too-many-branches
@@ -706,6 +692,14 @@ def open_rasterio(
         Group name or names to use to filter loading.
     default_name: str, optional
         The name of the data array if none exists. Default is None.
+    decode_times: bool, optional
+        If True, decode times encoded in the standard NetCDF datetime format
+        into datetime objects. Otherwise, leave them encoded as numbers.
+    decode_timedelta: bool, optional
+        If True, decode variables and coordinates with time units in
+        {“days”, “hours”, “minutes”, “seconds”, “milliseconds”, “microseconds”}
+        into timedelta objects. If False, leave them encoded as numbers.
+        If None (default), assume the same value of decode_time.
     **open_kwargs: kwargs, optional
         Optional keyword arguments to pass into rasterio.open().
 
@@ -777,6 +771,9 @@ def open_rasterio(
             lock=lock,
             masked=masked,
             mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            decode_timedelta=decode_timedelta,
+            **open_kwargs,
         )
 
     if vrt_params is not None:
@@ -840,7 +837,9 @@ def open_rasterio(
 
     # update attributes from NetCDF attributess
     _load_netcdf_attrs(riods.tags(), result)
-    result = _decode_datetime_cf(result)
+    result = _decode_datetime_cf(
+        result, decode_times=decode_times, decode_timedelta=decode_timedelta
+    )
 
     # make sure the _FillValue is correct dtype
     if "_FillValue" in attrs:

--- a/rioxarray/xarray_plugin.py
+++ b/rioxarray/xarray_plugin.py
@@ -41,6 +41,8 @@ class RasterioBackend(xr.backends.common.BackendEntrypoint):
         variable=None,
         group=None,
         default_name="band_data",
+        decode_times=True,
+        decode_timedelta=None,
         open_kwargs=None,
     ):
         if open_kwargs is None:
@@ -56,6 +58,8 @@ class RasterioBackend(xr.backends.common.BackendEntrypoint):
             variable=variable,
             group=group,
             default_name=default_name,
+            decode_times=decode_times,
+            decode_timedelta=decode_timedelta,
             **open_kwargs,
         )
         if isinstance(ds, xr.DataArray):

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -981,6 +981,27 @@ def test_nc_attr_loading(open_rasterio):
         assert str(rds.time.values[1]) == "2016-12-29 12:52:42.347451"
 
 
+@pytest.mark.xfail(
+    LooseVersion(rasterio.__gdal_version__) < LooseVersion("3.0.4"),
+    reason="This was fixed in GDAL 3.0.4",
+)
+def test_nc_attr_loading__disable_decode_times(open_rasterio):
+    with open_rasterio(
+        os.path.join(TEST_INPUT_DATA_DIR, "PLANET_SCOPE_3D.nc"), decode_times=False
+    ) as rds:
+        assert rds.dims == {"y": 10, "x": 10, "time": 2}
+        assert rds.attrs == {"coordinates": "spatial_ref"}
+        assert rds.y.attrs["units"] == "metre"
+        assert rds.x.attrs["units"] == "metre"
+        assert rds.time.encoding == {}
+        assert np.isnan(rds.time.attrs.pop("_FillValue"))
+        assert rds.time.attrs == {
+            "units": "seconds since 2016-12-19T10:27:29.687763",
+            "calendar": "proleptic_gregorian",
+        }
+        assert_array_equal(rds.time.values, [0, 872712.659688])
+
+
 def test_lockless():
     with rioxarray.open_rasterio(
         os.path.join(TEST_INPUT_DATA_DIR, "PLANET_SCOPE_3D.nc"), lock=False, chunks=True


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #316
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
