### PR TITLE
TST: Update tests for rasterio 1.2.3

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,6 +14,7 @@ TEST_INPUT_DATA_DIR = os.path.join(TEST_DATA_DIR, "input")
 TEST_COMPARE_DATA_DIR = os.path.join(TEST_DATA_DIR, "compare")
 PYPROJ_LT_3 = LooseVersion(pyproj.__version__) < LooseVersion("3")
 RASTERIO_LT_122 = LooseVersion(rasterio.__version__) < LooseVersion("1.2.2")
+RASTERIO_EQ_122 = LooseVersion(rasterio.__version__) == LooseVersion("1.2.2")
 
 
 # xarray.testing.assert_equal(input_xarray, compare_xarray)

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -30,6 +30,7 @@ from rioxarray.exceptions import (
 from rioxarray.rioxarray import _make_coords
 from test.conftest import (
     PYPROJ_LT_3,
+    RASTERIO_EQ_122,
     RASTERIO_LT_122,
     TEST_COMPARE_DATA_DIR,
     TEST_INPUT_DATA_DIR,
@@ -350,15 +351,15 @@ def test_clip_box__one_dimension_error(modis_clip):
         var_match = ""
         if hasattr(xdi, "name") and xdi.name:
             var_match = " Data variable: __xarray_dataarray_variable__"
-        if RASTERIO_LT_122:
+        if RASTERIO_EQ_122:
+            expected_exception = rasterio.errors.WindowError
+            var_match = "Bounds and transform are inconsistent"
+        else:
             expected_exception = OneDimensionalRaster
             var_match = (
                 "At least one of the clipped raster x,y coordinates has "
                 f"only one point.{var_match}"
             )
-        else:
-            expected_exception = rasterio.errors.WindowError
-            var_match = "Bounds and transform are inconsistent"
         # test exception after raster clipped
         with pytest.raises(
             expected_exception,


### PR DESCRIPTION
https://github.com/mapbox/rasterio/blob/06a292dc5a30e483792d7083dc75da9c46ade50b/CHANGES.txt#L4-L16
```
Fix a regression introduced in 1.2.2: from_bounds() can again return Windows of zero height or width.
```