### PR TITLE
TST: Update backend entrypoint importorskip for xarray 0.18

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -97,8 +97,7 @@ def _assert_xarrays_equal(
 
 
 def open_rasterio_engine(file_name_or_object, **kwargs):
-    # FIXME: change to the next xarray version after release
-    xr = pytest.importorskip("xarray", minversion="0.17.1.dev0")
+    xr = pytest.importorskip("xarray", minversion="0.18")
     return xr.open_dataset(file_name_or_object, engine="rasterio", **kwargs)
 
 

--- a/test/integration/test_integration_xarray_plugin.py
+++ b/test/integration/test_integration_xarray_plugin.py
@@ -5,8 +5,7 @@ import pytest
 from rioxarray.exceptions import RioXarrayError
 from test.conftest import TEST_INPUT_DATA_DIR
 
-# FIXME: change to the next xarray version after release
-xr = pytest.importorskip("xarray", minversion="0.17.1.dev0")
+xr = pytest.importorskip("xarray", minversion="0.18")
 
 
 def test_xarray_open_dataset():


### PR DESCRIPTION
0.18 was released a little while ago.