### PR TITLE
TST: Use pytest-timeout for tests over network

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("README.rst") as readme_file:
 
 requirements = ["rasterio", "scipy", "xarray>=0.17", "pyproj>=2.2"]
 
-test_requirements = ["pytest>=3.6", "pytest-cov", "dask"]
+test_requirements = ["pytest>=3.6", "pytest-cov", "pytest-timeout", "dask", "netcdf4"]
 doc_requirements = ["sphinx-click==1.1.0", "nbsphinx", "sphinx_rtd_theme"]
 
 extras_require = {

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -759,6 +759,7 @@ def test_no_mftime():
                 assert_allclose(actual, expected)
 
 
+@pytest.mark.timeout(30)
 @pytest.mark.xfail(
     error=rasterio.errors.RasterioIOError, reason="Network could be problematic"
 )
@@ -829,7 +830,10 @@ def test_rasterio_vrt_with_transform_and_size():
                     assert rds.rio.transform() == vrt.transform
 
 
-@pytest.mark.xfail(reason="Network could be problematic")
+@pytest.mark.timeout(30)
+@pytest.mark.xfail(
+    error=rasterio.errors.RasterioIOError, reason="Network could be problematic"
+)
 def test_rasterio_vrt_network():
     url = "https://storage.googleapis.com/\
     gcp-public-data-landsat/LC08/01/047/027/\


### PR DESCRIPTION
This randomly runs for 6hr+: https://github.com/corteva/rioxarray/runs/2648057792