### PR TITLE
BUG: pass kwargs with lock=False

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,7 @@ History
 
 Latest
 ------
-
+- BUG: pass kwargs with lock=False (issue #344)
 
 0.4.0
 ------

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -53,7 +53,7 @@ class URIManager(FileManager):
         self._kwargs = {} if kwargs is None else dict(kwargs)
 
     def acquire(self, needs_lock=True):
-        return self._opener(*self._args, mode=self._mode, kwargs=self._kwargs)
+        return self._opener(*self._args, mode=self._mode, **self._kwargs)
 
     def acquire_context(self, needs_lock=True):
         yield self.acquire(needs_lock=needs_lock)

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -868,11 +868,12 @@ def test_rasterio_vrt_with_src_crs():
                     assert rds.rio.crs == src_crs
 
 
-def test_open_cog():
+@pytest.mark.parametrize("lock", [True, False])
+def test_open_cog(lock):
     cog_file = os.path.join(TEST_INPUT_DATA_DIR, "cog.tif")
     rdsm = rioxarray.open_rasterio(cog_file)
     assert rdsm.shape == (1, 500, 500)
-    rdso = rioxarray.open_rasterio(cog_file, overview_level=0)
+    rdso = rioxarray.open_rasterio(cog_file, lock=lock, overview_level=0)
     assert rdso.shape == (1, 250, 250)
 
 


### PR DESCRIPTION

 - [x] Closes #344
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

Separated out changes for clarity.