### PR TITLE
BUG: Preserve original dtype if originally complex_int16

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -896,7 +896,7 @@ def open_rasterio(
         unsigned = variables.pop_to(attrs, encoding, "_Unsigned") == "true"
 
     if masked:
-        encoding["dtype"] = _rasterio_to_numpy_dtype(riods.dtypes)
+        encoding["dtype"] = str(_rasterio_to_numpy_dtype(riods.dtypes))
 
     da_name = attrs.pop("NETCDF_VARNAME", default_name)
     data = indexing.LazilyOuterIndexedArray(
@@ -950,4 +950,5 @@ def open_rasterio(
     result.rio._manager = manager
     # add file path to encoding
     result.encoding["source"] = riods.name
+    result.encoding["rasterio_dtype"] = str(riods.dtypes[0])
     return result


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Continuation of #352
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

cc: @scottyhq 