### PR TITLE
ENH: kwargs & gcps support for rio.reproject

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Env
         shell: bash
         run: |
-          conda create -n test python=${{ matrix.python-version }} rasterio=${{ matrix.rasterio-version }} xarray=${{ matrix.xarray-version }} scipy pyproj netcdf4 dask pandoc
+          conda create -n test python=${{ matrix.python-version }} rasterio=${{ matrix.rasterio-version }} xarray=${{ matrix.xarray-version }} 'libgdal<3.3' scipy pyproj netcdf4 dask pandoc
           source activate test
           python -m pip install -e .[all]
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,8 +3,9 @@ History
 
 Latest
 ------
-- ENH: Allow passing in kwargs to reproject & overide nodata. Provide
-default nodata based on dtype. (issue ##369)
+- ENH: Allow passing in kwargs to `rio.reproject` (issue #369; pull #370)
+- ENH: Allow nodata override and provide default nodata based on dtype in `rio.reproject` (pull #370)
+- ENH: Add support for passing in gcps to rio.reproject (issue #339; pull #370)
 - BUG: Remove duplicate acquire in open_rasterio (pull #364)
 
 0.4.3

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,9 @@ History
 
 Latest
 ------
-- BUG: Remove duplicate acquire in open_rasterio
+- ENH: Allow passing in kwargs to reproject & overide nodata. Provide
+default nodata based on dtype. (issue ##369)
+- BUG: Remove duplicate acquire in open_rasterio (pull #364)
 
 0.4.3
 ------

--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -18,6 +18,7 @@ import rasterio
 import rasterio.mask
 import rasterio.warp
 import xarray
+from rasterio.dtypes import dtype_rev
 from rasterio.enums import Resampling
 from rasterio.features import geometry_mask
 from scipy.interpolate import griddata
@@ -37,6 +38,24 @@ from rioxarray.raster_writer import (
     _ensure_nodata_dtype,
 )
 from rioxarray.rioxarray import XRasterBase, _get_data_var_message, _make_coords
+
+# DTYPE TO NODATA MAP
+# Based on: https://github.com/OSGeo/gdal/blob/
+# cde27dc7641964a872efdc6bbcf5e3d3f7ab9cfd/gdal/
+# swig/python/gdal-utils/osgeo_utils/gdal_calc.py#L62
+_NODATA_DTYPE_MAP = {
+    1: 255,  # GDT_Byte
+    2: 65535,  # GDT_UInt16
+    3: -32768,  # GDT_Int16
+    4: 4294967293,  # GDT_UInt32
+    5: -2147483647,  # GDT_Int32
+    6: 3.402823466e38,  # GDT_Float32
+    7: 1.7976931348623158e308,  # GDT_Float64
+    8: -32768,  # GDT_CInt16
+    9: -2147483647,  # GDT_CInt32
+    10: 3.402823466e38,  # GDT_CFloat32
+    11: 1.7976931348623158e308,  # GDT_CFloat64
+}
 
 
 def _generate_attrs(src_data_array, dst_nodata):
@@ -318,7 +337,9 @@ class RasterArray(XRasterBase):
         resolution=None,
         shape=None,
         transform=None,
+        nodata=None,
         resampling=Resampling.nearest,
+        **kwargs,
     ):
         """
         Reproject :obj:`xarray.DataArray` objects
@@ -332,6 +353,7 @@ class RasterArray(XRasterBase):
 
         .. versionadded:: 0.0.27 shape
         .. versionadded:: 0.0.28 transform
+        .. versionadded:: 0.5.0 nodata, kwargs
 
         Parameters
         ----------
@@ -343,10 +365,21 @@ class RasterArray(XRasterBase):
         shape: tuple(int, int), optional
             Shape of the destination in pixels (dst_height, dst_width). Cannot be used
             together with resolution.
-        transform: optional
+        transform: Affine, optional
             The destination transform.
         resampling: rasterio.enums.Resampling, optional
             See :func:`rasterio.warp.reproject` for more details.
+        nodata: float, optional
+            The nodata value used to initialize the destination;
+            it will remain in all areas not covered by the reprojected source.
+            Defaults to the nodata value of the source image if none provided
+            and exists or attempts to find an appropriate value by dtype.
+        **kwargs: dict
+            Additional keyword arguments to pass into :func:`rasterio.warp.reproject`.
+            To override:
+            - src_transform: `rio.write_transform`
+            - src_crs: `rio.write_crs`
+            - src_nodata: `rio.write_nodata`
 
 
         Returns
@@ -382,22 +415,24 @@ class RasterArray(XRasterBase):
         else:
             dst_data = np.zeros((dst_height, dst_width), dtype=self._obj.dtype.type)
 
-        dst_nodata = self._obj.dtype.type(
-            self.nodata if self.nodata is not None else -9999
+        default_nodata = (
+            _NODATA_DTYPE_MAP[dtype_rev[self._obj.dtype.name]]
+            if self.nodata is None
+            else self.nodata
         )
-        src_nodata = self._obj.dtype.type(
-            self.nodata if self.nodata is not None else dst_nodata
-        )
+        dst_nodata = default_nodata if nodata is None else nodata
+
         rasterio.warp.reproject(
             source=self._obj.values,
             destination=dst_data,
             src_transform=src_affine,
             src_crs=self.crs,
-            src_nodata=src_nodata,
+            src_nodata=self.nodata,
             dst_transform=dst_affine,
             dst_crs=dst_crs,
             dst_nodata=dst_nodata,
             resampling=resampling,
+            **kwargs,
         )
         # add necessary attributes
         new_attrs = _generate_attrs(self._obj, dst_nodata)

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -58,6 +58,8 @@ class RasterDataset(XRasterBase):
         shape=None,
         transform=None,
         resampling=Resampling.nearest,
+        nodata=None,
+        **kwargs,
     ):
         """
         Reproject :class:`xarray.Dataset` objects
@@ -69,6 +71,7 @@ class RasterDataset(XRasterBase):
 
         .. versionadded:: 0.0.27 shape
         .. versionadded:: 0.0.28 transform
+        .. versionadded:: 0.5.0 nodata, kwargs
 
         Parameters
         ----------
@@ -84,7 +87,17 @@ class RasterDataset(XRasterBase):
             The destination transform.
         resampling: rasterio.enums.Resampling, optional
             See :func:`rasterio.warp.reproject` for more details.
-
+        nodata: float, optional
+            The nodata value used to initialize the destination;
+            it will remain in all areas not covered by the reprojected source.
+            Defaults to the nodata value of the source image if none provided
+            and exists or attempts to find an appropriate value by dtype.
+        **kwargs: dict
+            Additional keyword arguments to pass into :func:`rasterio.warp.reproject`.
+            To override:
+            - src_transform: `rio.write_transform`
+            - src_crs: `rio.write_crs`
+            - src_nodata: `rio.write_nodata`
 
         Returns
         --------
@@ -102,6 +115,8 @@ class RasterDataset(XRasterBase):
                     shape=shape,
                     transform=transform,
                     resampling=resampling,
+                    nodata=nodata,
+                    **kwargs,
                 )
             )
         return resampled_dataset

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -721,10 +721,10 @@ def test_reproject__no_nodata(modis_reproject):
         # replace -9999 with original _FillValue for testing
         if hasattr(mds_repr, "variables"):
             for var in mds_repr.rio.vars:
-                mds_repr[var].values[mds_repr[var].values == -9999] = orig_fill
+                mds_repr[var].values[mds_repr[var].values == -32768] = orig_fill
         else:
-            mds_repr.values[mds_repr.values == -9999] = orig_fill
-        _mod_attr(mdc, "_FillValue", val=-9999)
+            mds_repr.values[mds_repr.values == -32768] = orig_fill
+        _mod_attr(mdc, "_FillValue", val=-32768)
         # test
         _assert_xarrays_equal(mds_repr, mdc)
 
@@ -1069,6 +1069,7 @@ def test_geographic_reproject__missing_nodata():
         mds_repr = mda.rio.reproject("epsg:32721")
         # mds_repr.to_netcdf(sentinel_2_utm)
         # test
+        _mod_attr(mdc, "_FillValue", val=65535)
         _assert_xarrays_equal(mds_repr, mdc, precision=4)
 
 

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -15,6 +15,7 @@ from affine import Affine
 from dask.delayed import Delayed
 from numpy.testing import assert_almost_equal, assert_array_equal
 from pyproj import CRS as pCRS
+from rasterio.control import GroundControlPoint
 from rasterio.crs import CRS
 from rasterio.windows import Window
 
@@ -699,7 +700,8 @@ def test_reproject__no_transform(modis_reproject):
         _assert_xarrays_equal(mds_repr, mdc)
 
 
-def test_reproject__no_nodata(modis_reproject):
+@pytest.mark.parametrize("nodata", [None, -9999])
+def test_reproject__no_nodata(nodata, modis_reproject):
     mask_args = (
         dict(masked=False, mask_and_scale=False)
         if "rasterio" in str(modis_reproject["open"])
@@ -712,19 +714,20 @@ def test_reproject__no_nodata(modis_reproject):
         _del_attr(mda, "_FillValue")
         _del_attr(mda, "nodata")
         # reproject
-        mds_repr = mda.rio.reproject(modis_reproject["to_proj"])
+        mds_repr = mda.rio.reproject(modis_reproject["to_proj"], nodata=nodata)
 
         # overwrite test dataset
         # if isinstance(modis_reproject['open'], xarray.DataArray):
         #    mds_repr.to_netcdf(modis_reproject['compare'])
 
         # replace -9999 with original _FillValue for testing
+        fill_nodata = -32768 if nodata is None else nodata
         if hasattr(mds_repr, "variables"):
             for var in mds_repr.rio.vars:
-                mds_repr[var].values[mds_repr[var].values == -32768] = orig_fill
+                mds_repr[var].values[mds_repr[var].values == fill_nodata] = orig_fill
         else:
-            mds_repr.values[mds_repr.values == -32768] = orig_fill
-        _mod_attr(mdc, "_FillValue", val=-32768)
+            mds_repr.values[mds_repr.values == fill_nodata] = orig_fill
+        _mod_attr(mdc, "_FillValue", val=fill_nodata)
         # test
         _assert_xarrays_equal(mds_repr, mdc)
 
@@ -748,6 +751,47 @@ def test_reproject__no_nodata_masked(modis_reproject):
         mds_repr = mda.rio.reproject(modis_reproject["to_proj"])
         # test
         _assert_xarrays_equal(mds_repr, mdc)
+
+
+def test_reproject__gcps_kwargs(tmp_path):
+    tiffname = tmp_path / "test.tif"
+    src_gcps = [
+        GroundControlPoint(row=0, col=0, x=156113, y=2818720, z=0),
+        GroundControlPoint(row=0, col=800, x=338353, y=2785790, z=0),
+        GroundControlPoint(row=800, col=800, x=297939, y=2618518, z=0),
+        GroundControlPoint(row=800, col=0, x=115698, y=2651448, z=0),
+    ]
+    crs = CRS.from_epsg(32618)
+    with rasterio.open(
+        tiffname,
+        mode="w",
+        height=800,
+        width=800,
+        count=3,
+        dtype=numpy.uint8,
+        driver="GTiff",
+    ) as source:
+        source.gcps = (src_gcps, crs)
+
+    rds = rioxarray.open_rasterio(tiffname)
+    rds.rio.write_crs(crs, inplace=True)
+    rds = rds.rio.reproject(
+        crs,
+        gcps=src_gcps,
+    )
+    assert rds.rio.height == 923
+    assert rds.rio.width == 1027
+    assert rds.rio.crs == crs
+    assert rds.rio.transform().almost_equals(
+        Affine(
+            216.8587081056465,
+            0.0,
+            115698.25,
+            0.0,
+            -216.8587081056465,
+            2818720.0,
+        )
+    )
 
 
 def test_reproject_match(modis_reproject_match):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #369 
 - [x] Part of #339
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API


This one snowballed a bit:
```
- ENH: Allow passing in kwargs to rio.reproject (issue #369)
- ENH: Allow nodata override and provide default nodata based on dtype in rio.reproject
- ENH: Add support for passing in gcps to rio.reproject (issue #339)
```