### PR TITLE
DOC: remove set_spatial_dims suggestion in DimensionError

### DIFF
--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -721,7 +721,7 @@ class XRasterBase:
         if self._x_dim is not None:
             return self._x_dim
         raise DimensionError(
-            "x dimension not found. 'rio.set_spatial_dims()' or "
+            "x dimension not found. "
             "using 'rename()' to change the dimension name to 'x' can address this."
             f"{_get_data_var_message(self._obj)}"
         )
@@ -732,7 +732,7 @@ class XRasterBase:
         if self._y_dim is not None:
             return self._y_dim
         raise DimensionError(
-            "y dimension not found. 'rio.set_spatial_dims()' or "
+            "y dimension not found. "
             "using 'rename()' to change the dimension name to 'y' can address this."
             f"{_get_data_var_message(self._obj)}"
         )


### PR DESCRIPTION
 - [x] Closes #372

The suggestion in https://github.com/corteva/rioxarray/issues/372#issuecomment-875041884 doesn't work.

This may not fix/explain why using `set_spatial_dims` doesn't work with `to_raster` but it removes the suggestion to use `set_spatial_dims` as the issue thread shows it doesn't work.

I think this is fine to just suggest/request users to rename dimensions before writing to raster.