### PR TITLE
BUG: Skip non-geospatial arrays in datasets when clipping

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- BUG: `rio.clip` and `rio.clip_box` skip non-geospatial arrays in datasets when clipping (pull #392)
 
 0.6.1
 ------

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -191,7 +191,7 @@ class RasterDataset(XRasterBase):
         )
 
     def clip_box(self, minx, miny, maxx, maxy, auto_expand=False, auto_expand_limit=3):
-        """Clip the :class:`xarray.Dataset` by a bounding box.
+        """Clip the :class:`xarray.Dataset` by a bounding box in dimensions 'x'/'y'.
 
         .. warning:: Clips variables that have dimensions 'x'/'y'. Others are appended as is.
 
@@ -249,7 +249,7 @@ class RasterDataset(XRasterBase):
         from_disk=False,
     ):
         """
-        Crops a :class:`xarray.Dataset` by geojson like geometry dicts.
+        Crops a :class:`xarray.Dataset` by geojson like geometry dicts in dimensions 'x'/'y'.
 
         .. warning:: Clips variables that have dimensions 'x'/'y'. Others are appended as is.
 

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -218,8 +218,7 @@ class RasterDataset(XRasterBase):
         """
         clipped_dataset = xarray.Dataset(attrs=self._obj.attrs)
         for var in self.vars:
-            if hasattr(self._obj[var], self.x_dim) \
-                    and hasattr(self._obj[var], self.y_dim):
+            if self.x_dim in self._obj[var].dims and self.y_dim in self._obj[var].dims:
                 clipped_dataset[var] = (
                     self._obj[var]
                     .rio.set_spatial_dims(
@@ -303,8 +302,7 @@ class RasterDataset(XRasterBase):
         """
         clipped_dataset = xarray.Dataset(attrs=self._obj.attrs)
         for var in self.vars:
-            if hasattr(self._obj[var], self.x_dim) \
-                    and hasattr(self._obj[var], self.y_dim):
+            if self.x_dim in self._obj[var].dims and self.y_dim in self._obj[var].dims:
                 clipped_dataset[var] = (
                     self._obj[var]
                     .rio.set_spatial_dims(

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -219,7 +219,7 @@ class RasterDataset(XRasterBase):
         clipped_dataset = xarray.Dataset(attrs=self._obj.attrs)
         for var in self.vars:
             if hasattr(self._obj[var], self.x_dim) \
-                and hasattr(self._obj[var], self.y_dim):
+                    and hasattr(self._obj[var], self.y_dim):
                 clipped_dataset[var] = (
                     self._obj[var]
                     .rio.set_spatial_dims(
@@ -304,7 +304,7 @@ class RasterDataset(XRasterBase):
         clipped_dataset = xarray.Dataset(attrs=self._obj.attrs)
         for var in self.vars:
             if hasattr(self._obj[var], self.x_dim) \
-                and hasattr(self._obj[var], self.y_dim):
+                    and hasattr(self._obj[var], self.y_dim):
                 clipped_dataset[var] = (
                     self._obj[var]
                     .rio.set_spatial_dims(

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -307,7 +307,9 @@ class RasterDataset(XRasterBase):
             else:
                 clipped_dataset[var] = (
                     self._obj[var]
-                    .rio.set_spatial_dims(x_dim=self.x_dim, y_dim=self.y_dim, inplace=True)
+                    .rio.set_spatial_dims(
+                        x_dim=self.x_dim, y_dim=self.y_dim, inplace=True
+                    )
                     .rio.clip(
                         geometries,
                         crs=crs,

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -218,7 +218,8 @@ class RasterDataset(XRasterBase):
         """
         clipped_dataset = xarray.Dataset(attrs=self._obj.attrs)
         for var in self.vars:
-            if hasattr(self._obj[var], self.x_dim) and hasattr(self._obj[var], self.y_dim):
+            if hasattr(self._obj[var], self.x_dim) \
+                and hasattr(self._obj[var], self.y_dim):
                 clipped_dataset[var] = (
                     self._obj[var]
                     .rio.set_spatial_dims(
@@ -302,7 +303,8 @@ class RasterDataset(XRasterBase):
         """
         clipped_dataset = xarray.Dataset(attrs=self._obj.attrs)
         for var in self.vars:
-            if hasattr(self._obj[var], self.x_dim) and hasattr(self._obj[var], self.y_dim):
+            if hasattr(self._obj[var], self.x_dim) \
+                and hasattr(self._obj[var], self.y_dim):
                 clipped_dataset[var] = (
                     self._obj[var]
                     .rio.set_spatial_dims(

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -489,10 +489,10 @@ def test_clip_geojson(open_func, from_disk):
 @pytest.mark.parametrize(
     "invert, from_disk, expected_sum",
     [
-        (False, False, 2150801411),  # 2150837592),
-        (True, False, 535727386),  # 535691205),
-        (False, True, 2150801411),  # 2150837592),
-        (True, True, 535727386),  # 535691205),
+        (False, False, 2150837592),
+        (True, False, 535691205),
+        (False, True, 2150837592),
+        (True, True, 535691205),
     ],
 )
 @pytest.mark.parametrize(

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -489,10 +489,10 @@ def test_clip_geojson(open_func, from_disk):
 @pytest.mark.parametrize(
     "invert, from_disk, expected_sum",
     [
-        (False, False, 2150837592),
-        (True, False, 535691205),
-        (False, True, 2150837592),
-        (True, True, 535691205),
+        (False, False, 2150801411),  # 2150837592),
+        (True, False, 535727386),  # 535691205),
+        (False, True, 2150801411),  # 2150837592),
+        (True, True, 535727386),  # 535691205),
     ],
 )
 @pytest.mark.parametrize(

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -484,6 +484,31 @@ def test_clip_geojson(open_func, from_disk):
             clipped_ds.rio.transform(),
             (3.0, 0.0, 425500.68381405267, 0.0, -3.0, 4615477.040546387, 0.0, 0.0, 1.0),
         )
+        times = numpy.arange(6)
+        x = numpy.linspace(425493.18381405, 425532.18381405, num=6)
+        y = numpy.linspace(4615295.54054639, 4615514.54054639, num=6)
+        print(x, y)
+        ds = xarray.Dataset(
+            {
+                "stuff": xarray.DataArray(
+                    data=numpy.zeros((6, 6, 6), dtype=float),
+                    dims=["time", "x", "y"],
+                    coords={
+                        "time": times,
+                        "x": x,
+                        "y": y,
+                    },
+                )
+            }
+        )
+        ds.rio.set_spatial_dims(x_dim="x", y_dim="y", inplace=True)
+        ds.rio.write_crs("EPSG:26915", inplace=True)
+        ds["meta"] = ("time", numpy.random.random(6))
+
+        assert ds.stuff.shape == (6, 6, 6)
+        clip_ds = ds.rio.clip(geometries)
+        assert clip_ds.stuff.shape == (6, 4, 4)
+        assert "meta" in clip_ds.data_vars
 
 
 @pytest.mark.parametrize(

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -540,22 +540,7 @@ def test_clip_geojson__no_drop(open_func, invert, from_disk, expected_sum):
         assert clipped_ds.test_data.rio.nodata == xdi.rio.nodata
 
 
-def test_clip_clip_box__non_geospatial():
-    # check for variables without spatial dims
-    geometries = [
-        {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [425499.18381405267, 4615331.540546387],
-                    [425499.18381405267, 4615478.540546387],
-                    [425526.18381405267, 4615478.540546387],
-                    [425526.18381405267, 4615331.540546387],
-                    [425499.18381405267, 4615331.540546387],
-                ]
-            ],
-        }
-    ]
+def dummy_dataset_non_geospatial():
     times = numpy.arange(6)
     x = numpy.linspace(425493.18381405, 425532.18381405, num=6)
     y = numpy.linspace(4615295.54054639, 4615514.54054639, num=6)
@@ -575,11 +560,34 @@ def test_clip_clip_box__non_geospatial():
     ds.rio.set_spatial_dims(x_dim="x", y_dim="y", inplace=True)
     ds.rio.write_crs("EPSG:26915", inplace=True)
     ds["meta"] = ("time", numpy.random.random(6))
+    return ds
 
+
+def test_clip__non_geospatial():
+    # check for variables without spatial dims
+    geometries = [
+        {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [425499.18381405267, 4615331.540546387],
+                    [425499.18381405267, 4615478.540546387],
+                    [425526.18381405267, 4615478.540546387],
+                    [425526.18381405267, 4615331.540546387],
+                    [425499.18381405267, 4615331.540546387],
+                ]
+            ],
+        }
+    ]
+    ds = dummy_dataset_non_geospatial()
     assert ds.stuff.shape == (6, 6, 6)
     ds_clip = ds.rio.clip(geometries)
     assert ds_clip.stuff.shape == (6, 4, 4)
     assert "meta" in ds_clip.data_vars
+
+
+def test_clip_box__non_geospatial():
+    ds = dummy_dataset_non_geospatial()
     ds_clip_box = ds.rio.clip_box(
         minx=425500.18381405,
         miny=4615395.54054639,

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -298,6 +298,37 @@ def test_clip_box(modis_clip):
         assert_almost_equal(clipped_ds.rio.transform(), xdc.rio.transform())
         # make sure it safely writes to netcdf
         clipped_ds.to_netcdf(modis_clip["output"])
+        # check for variables without spatial dims
+        times = numpy.arange(6)
+        x = numpy.linspace(425493.18381405, 425532.18381405, num=6)
+        y = numpy.linspace(4615295.54054639, 4615514.54054639, num=6)
+        print(x, y)
+        ds = xarray.Dataset(
+            {
+                "stuff": xarray.DataArray(
+                    data=numpy.zeros((6, 6, 6), dtype=float),
+                    dims=["time", "x", "y"],
+                    coords={
+                        "time": times,
+                        "x": x,
+                        "y": y,
+                    },
+                )
+            }
+        )
+        ds.rio.set_spatial_dims(x_dim="x", y_dim="y", inplace=True)
+        ds.rio.write_crs("EPSG:26915", inplace=True)
+        ds["meta"] = ("time", numpy.random.random(6))
+
+        assert ds.stuff.shape == (6, 6, 6)
+        clip_ds = ds.rio.clip_box(
+            minx=425500.18381405,
+            miny=4615395.54054639,
+            maxx=425520.18381405,
+            maxy=4615414.54054639,
+        )
+        assert clip_ds.stuff.shape == (6, 3, 2)
+        assert "meta" in clip_ds.data_vars
 
 
 def test_clip_box__auto_expand(modis_clip):
@@ -484,6 +515,7 @@ def test_clip_geojson(open_func, from_disk):
             clipped_ds.rio.transform(),
             (3.0, 0.0, 425500.68381405267, 0.0, -3.0, 4615477.040546387, 0.0, 0.0, 1.0),
         )
+        # check for variables without spatial dims
         times = numpy.arange(6)
         x = numpy.linspace(425493.18381405, 425532.18381405, num=6)
         y = numpy.linspace(4615295.54054639, 4615514.54054639, num=6)

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -298,37 +298,6 @@ def test_clip_box(modis_clip):
         assert_almost_equal(clipped_ds.rio.transform(), xdc.rio.transform())
         # make sure it safely writes to netcdf
         clipped_ds.to_netcdf(modis_clip["output"])
-        # check for variables without spatial dims
-        times = numpy.arange(6)
-        x = numpy.linspace(425493.18381405, 425532.18381405, num=6)
-        y = numpy.linspace(4615295.54054639, 4615514.54054639, num=6)
-        print(x, y)
-        ds = xarray.Dataset(
-            {
-                "stuff": xarray.DataArray(
-                    data=numpy.zeros((6, 6, 6), dtype=float),
-                    dims=["time", "x", "y"],
-                    coords={
-                        "time": times,
-                        "x": x,
-                        "y": y,
-                    },
-                )
-            }
-        )
-        ds.rio.set_spatial_dims(x_dim="x", y_dim="y", inplace=True)
-        ds.rio.write_crs("EPSG:26915", inplace=True)
-        ds["meta"] = ("time", numpy.random.random(6))
-
-        assert ds.stuff.shape == (6, 6, 6)
-        clip_ds = ds.rio.clip_box(
-            minx=425500.18381405,
-            miny=4615395.54054639,
-            maxx=425520.18381405,
-            maxy=4615414.54054639,
-        )
-        assert clip_ds.stuff.shape == (6, 3, 2)
-        assert "meta" in clip_ds.data_vars
 
 
 def test_clip_box__auto_expand(modis_clip):
@@ -515,32 +484,6 @@ def test_clip_geojson(open_func, from_disk):
             clipped_ds.rio.transform(),
             (3.0, 0.0, 425500.68381405267, 0.0, -3.0, 4615477.040546387, 0.0, 0.0, 1.0),
         )
-        # check for variables without spatial dims
-        times = numpy.arange(6)
-        x = numpy.linspace(425493.18381405, 425532.18381405, num=6)
-        y = numpy.linspace(4615295.54054639, 4615514.54054639, num=6)
-        print(x, y)
-        ds = xarray.Dataset(
-            {
-                "stuff": xarray.DataArray(
-                    data=numpy.zeros((6, 6, 6), dtype=float),
-                    dims=["time", "x", "y"],
-                    coords={
-                        "time": times,
-                        "x": x,
-                        "y": y,
-                    },
-                )
-            }
-        )
-        ds.rio.set_spatial_dims(x_dim="x", y_dim="y", inplace=True)
-        ds.rio.write_crs("EPSG:26915", inplace=True)
-        ds["meta"] = ("time", numpy.random.random(6))
-
-        assert ds.stuff.shape == (6, 6, 6)
-        clip_ds = ds.rio.clip(geometries)
-        assert clip_ds.stuff.shape == (6, 4, 4)
-        assert "meta" in clip_ds.data_vars
 
 
 @pytest.mark.parametrize(
@@ -595,6 +538,56 @@ def test_clip_geojson__no_drop(open_func, invert, from_disk, expected_sum):
         assert clipped_ds.test_data.shape == xdi.shape
         assert clipped_ds.test_data.sum().item() == expected_sum
         assert clipped_ds.test_data.rio.nodata == xdi.rio.nodata
+
+
+def test_clip_clip_box__non_geospatial():
+    # check for variables without spatial dims
+    geometries = [
+        {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [425499.18381405267, 4615331.540546387],
+                    [425499.18381405267, 4615478.540546387],
+                    [425526.18381405267, 4615478.540546387],
+                    [425526.18381405267, 4615331.540546387],
+                    [425499.18381405267, 4615331.540546387],
+                ]
+            ],
+        }
+    ]
+    times = numpy.arange(6)
+    x = numpy.linspace(425493.18381405, 425532.18381405, num=6)
+    y = numpy.linspace(4615295.54054639, 4615514.54054639, num=6)
+    ds = xarray.Dataset(
+        {
+            "stuff": xarray.DataArray(
+                data=numpy.zeros((6, 6, 6), dtype=float),
+                dims=["time", "x", "y"],
+                coords={
+                    "time": times,
+                    "x": x,
+                    "y": y,
+                },
+            )
+        }
+    )
+    ds.rio.set_spatial_dims(x_dim="x", y_dim="y", inplace=True)
+    ds.rio.write_crs("EPSG:26915", inplace=True)
+    ds["meta"] = ("time", numpy.random.random(6))
+
+    assert ds.stuff.shape == (6, 6, 6)
+    ds_clip = ds.rio.clip(geometries)
+    assert ds_clip.stuff.shape == (6, 4, 4)
+    assert "meta" in ds_clip.data_vars
+    ds_clip_box = ds.rio.clip_box(
+        minx=425500.18381405,
+        miny=4615395.54054639,
+        maxx=425520.18381405,
+        maxy=4615414.54054639,
+    )
+    assert ds_clip_box.stuff.shape == (6, 3, 2)
+    assert "meta" in ds_clip_box.data_vars
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

Hello, first thanks for the great extension for xarray objects!

I added an argument to raster_dataset.clip to enable clipping only some of the variables, as i am storing metadata along with raster data, which only use the time axis. Maybe this workaround is useful for others.
Using the raster_array.clip, i was not able to drop the data outside of the mask in place, but maybe there is a better way to fix this.

Cheers!