### PR TITLE
ENH: Add option for users to skip variables without spatial dimensions

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 Latest
 ------
 - BUG: `rio.clip` and `rio.clip_box` skip non-geospatial arrays in datasets when clipping (pull #392)
+- ENH: Add option for users to skip variables without spatial dimensions (pull #395)
 
 0.6.1
 ------

--- a/rioxarray/_options.py
+++ b/rioxarray/_options.py
@@ -9,9 +9,11 @@ Source file: https://github.com/pydata/xarray/blob/2ab0666c1fcc493b1e0ebc7db1450
 from typing import Any
 
 EXPORT_GRID_MAPPING = "export_grid_mapping"
+SKIP_MISSING_SPATIAL_DIMS = "skip_missing_spatial_dims"
 
 OPTIONS = {
     EXPORT_GRID_MAPPING: True,
+    SKIP_MISSING_SPATIAL_DIMS: False,
 }
 OPTION_NAMES = set(OPTIONS)
 
@@ -23,6 +25,8 @@ VALIDATORS = {
 def get_option(key: str) -> Any:
     """
     Get the global rioxarray option.
+
+    .. versionadded:: 0.3.0
 
     Parameters
     ----------
@@ -40,15 +44,22 @@ class set_options:  # pylint: disable=invalid-name
     """
     Set the global rioxarray option.
 
+    .. versionadded:: 0.3.0
+    .. versionadded:: 0.7.0 skip_missing_spatial_dims
+
     Parameters
     ----------
-    export_grid_mapping: bool, optional
+    export_grid_mapping: bool, default=True
         If True, this option will export the full Climate and Forecasts (CF)
         grid mapping attributes for the CRS. This is useful if you are exporting
         your file to netCDF using :meth:`xarray.Dataset.to_netcdf()`. When disabled,
         only the ``crs_wkt`` and ``spatial_ref`` attributes will be written and the
         program will be faster due to not needing to use
-        :meth:`pyproj.CRS.to_cf() <pyproj.crs.CRS.to_cf>`. Default is True.
+        :meth:`pyproj.CRS.to_cf() <pyproj.crs.CRS.to_cf>`.
+    skip_missing_spatial_dims: bool, default=False
+        If True, it will not perform spatial operations on variables
+        within a :class:`xarray.Dataset` if the spatial dimensions
+        are not found.
 
 
     Usage as a context manager::

--- a/rioxarray/exceptions.py
+++ b/rioxarray/exceptions.py
@@ -19,6 +19,10 @@ class DimensionError(RioXarrayError):
     """This is raised when there are more dimensions than is supported by the method"""
 
 
+class MissingSpatialDimensionError(DimensionError):
+    """This is raised when the dimension cannot be found"""
+
+
 class TooManyDimensions(DimensionError):
     """This is raised when there are more dimensions than is supported by the method"""
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Building on to #392
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

The reason this was not enabled in the past was out of an abundance of caution. There are scenarios where spatial dimensions do exist on the Dataset/DataArray but rioxarray cannot find them. In this case, we definitely want to raise an exception.

If there is only 1 dimension, then by definition spatial dims don't exist, so don't raise an error in that scenario.

However, there are some scenarios where the spatial dimensions are known, but not all of the variables have the spatial dimensions. With this PR, the user can override those scenarios.

cc: @MarkusZehner