### PR TITLE
Read colortable and colorinterp from GeoTIFF as an attribute

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -534,7 +534,10 @@ def _get_rasterio_attrs(riods):
             attrs["units"] = riods.units
     if hasattr(riods, "colormap"):
         # A dict containing the colormap for a band
-        attrs["colormap"] = riods.colormap(1)
+        try:
+            attrs["colormap"] = riods.colormap(1)
+        except ValueError:  # NULL color table
+            pass
     if hasattr(riods, "colorinterp") and any(riods.colorinterp):
         # A tuple of the band's colorinterp property
         attrs["colorinterp"] = riods.colorinterp

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -532,6 +532,12 @@ def _get_rasterio_attrs(riods):
             attrs["units"] = riods.units[0]
         else:
             attrs["units"] = riods.units
+    if hasattr(riods, "colormap"):
+        # A dict containing the colormap for a band
+        attrs["colormap"] = riods.colormap(1)
+    if hasattr(riods, "colorinterp") and any(riods.colorinterp):
+        # A tuple of the band's colorinterp property
+        attrs["colorinterp"] = riods.colorinterp
 
     return attrs
 

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -245,6 +245,7 @@ def test_open_group_load_attrs(open_rasterio):
         assert sorted(attrs) == [
             "_FillValue",
             "add_offset",
+            "colorinterp",
             "long_name",
             "scale_factor",
             "units",
@@ -285,6 +286,7 @@ def test_open_rasterio_mask_chunk_clip():
         )
         assert attrs == {
             "add_offset": 0.0,
+            "colorinterp": (rasterio.enums.ColorInterp.gray,),
             "scale_factor": 1.0,
         }
 

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -1028,6 +1028,20 @@ def test_notgeoreferenced_warning(open_rasterio):
             open_rasterio(tmp_file)
 
 
+def test_geotiff_attr_loading(open_rasterio):
+    with open_rasterio(
+        "https://oceania.generic-mapping-tools.org/server/earth/earth_day/earth_day_01d_p.tif"
+    ) as rds:
+        rds = rds.band_data if hasattr(rds, "band_data") else rds
+
+        assert rds.dims == ("band", "y", "x")
+        assert rds.shape == (1, 180, 360)
+        # assert rds.attrs["scale_factor"] == 1.0
+        # assert rds.attrs["add_offset"] == 0.0
+        assert isinstance(rds.attrs["colormap"], dict)
+        assert rds.attrs["colorinterp"] == (rasterio.enums.ColorInterp.palette,)
+
+
 @pytest.mark.xfail(
     version.parse(rasterio.__gdal_version__) < version.parse("3.0.4"),
     reason="This was fixed in GDAL 3.0.4",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Preliminary support to read in color interpretation information from GeoTIFF files. Partially based on @alando46's code at https://github.com/pydata/xarray/pull/3136. Rasterio reference at https://rasterio.readthedocs.io/en/latest/topics/color.html

 - [ ] Addresses #191
 - [ ] Tests added
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
