### PR TITLE
TST: test_read_crs_cf updated for rasterio 1.2.9

### DIFF
--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1977,7 +1977,7 @@ def test_read_crs_cf():
     attrs = test_da.spatial_ref.attrs
     attrs.pop("spatial_ref")
     attrs.pop("crs_wkt")
-    assert test_da.rio.crs.to_epsg() == 4326
+    assert test_da.rio.crs.is_geographic
 
 
 def test_get_crs_dataset__nonstandard_grid_mapping():


### PR DESCRIPTION
https://github.com/corteva/rioxarray/runs/3779287156?check_suite_focus=true

Seems without the WKT, the confidence for the CF generated CRS is 60% that the code is `4326`, so it returns None as 70% is the threshold.
```python
[AuthorityMatchInfo(auth_name='EPSG', code='4326', confidence=60), AuthorityMatchInfo(auth_name='IGNF', code='ANAA92G', confidence=60), AuthorityMatchInfo(auth_name='IGNF', code='ST87G', confidence=60), AuthorityMatchInfo(auth_name='OGC', code='CRS84', confidence=60), AuthorityMatchInfo(auth_name='IGNF', code='WGS84GDD', confidence=60), AuthorityMatchInfo(auth_name='IGNF', code='WGS84G', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4762', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='6311', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='5365', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4755', confidence=60), AuthorityMatchInfo(auth_name='ESRI', code='104050', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4148', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='7136', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='7139', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4667', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4758', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4166', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4130', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4318', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4693', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='5340', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4694', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4763', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='5381', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='9470', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4750', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4757', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='7881', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4756', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='9055', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='9056', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='9057', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='9053', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='9054', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='8888', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4163', confidence=60), AuthorityMatchInfo(auth_name='EPSG', code='4326', confidence=25), AuthorityMatchInfo(auth_name='EPSG', code='4978', confidence=25), AuthorityMatchInfo(auth_name='EPSG', code='4979', confidence=25)]
```