### PR TITLE
BUG: Lazy load colormap through _manager.acquire() in merge

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 -------
+- BUG: Lazy load colormap through _manager.acquire() in merge (issue #479)
 
 0.10.1
 -------


### PR DESCRIPTION
 - [x] Closes #479
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
