### PR TITLE
Remove crs after rio crs

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,10 @@ History
 Latest
 -------
 
+0.10.3
+------
+- BUG: Remove underlying xarray `crs` once rioxarray's one is ready (issue #488)
+
 0.10.2
 -------
 - BUG: Lazy load colormap through _manager.acquire() in merge (issue #479)

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -313,6 +313,11 @@ class XRasterBase:
         crs = crs_from_user_input(input_crs)
         obj = self._get_obj(inplace=inplace)
         obj.rio._crs = crs
+
+        # Remove the crs from the underlying xarray to avoid confusion and force
+        # the user to manipulate the rioxarray controlled one.
+        if "crs" in self._obj.attrs:
+            del self._obj.attrs["crs"]
         return obj
 
     @property


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ x] Closes #488
 - [ x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
