### PR TITLE
DOC: Fix default value for inplace argument in RasterArray.set_nodata

### DIFF
--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -256,7 +256,7 @@ class RasterArray(XRasterBase):
         input_nodata: Optional[float]
             Valid nodata for dtype.
         inplace: bool, optional
-            If True, it will write to the existing dataset. Default is False.
+            If True, it will write to the existing dataset. Default is True.
 
         Returns
         -------


### PR DESCRIPTION
- Closes #508 

Docstring for default value of `inplace` argument to `RasterArray.set_nodata` is changed to match actual implemented value (True).