### PR TITLE
ENH: Add additional GDAL information to rioxarray.show_versions

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 Latest
 ------
 - TYPE: Add more type hints (issue #373)
+- ENH: Add additional GDAL information to :func:`rioxarray.show_versions` (pull #513)
 
 0.10.3
 ------

--- a/rioxarray/_show_versions.py
+++ b/rioxarray/_show_versions.py
@@ -6,6 +6,7 @@ which was adapted from :func:`pandas.show_versions`
 """
 # pylint: disable=import-outside-toplevel
 import importlib
+import os
 import platform
 import sys
 from typing import Dict
@@ -38,10 +39,23 @@ def _get_main_info() -> Dict[str, str]:
     import rasterio
     import xarray
 
+    try:
+        proj_data = os.pathsep.join(rasterio._env.get_proj_data_search_paths())
+    except AttributeError:
+        proj_data = None
+    try:
+        gdal_data = rasterio._env.get_gdal_data()
+    except AttributeError:
+        gdal_data = None
+
     blob = [
         ("rasterio", rasterio.__version__),
         ("xarray", xarray.__version__),
         ("GDAL", rasterio.__gdal_version__),
+        ("GEOS", getattr(rasterio, "__geos_version__", None)),
+        ("PROJ", getattr(rasterio, "__proj_version__", None)),
+        ("PROJ DATA", proj_data),
+        ("GDAL DATA", gdal_data),
     ]
 
     return dict(blob)

--- a/test/unit/test_show_versions.py
+++ b/test/unit/test_show_versions.py
@@ -11,6 +11,10 @@ def test_get_main_info():
     assert "rasterio" in pyproj_info
     assert "xarray" in pyproj_info
     assert "GDAL" in pyproj_info
+    assert "PROJ" in pyproj_info
+    assert "GEOS" in pyproj_info
+    assert "PROJ DATA" in pyproj_info
+    assert "GDAL DATA" in pyproj_info
 
 
 def test_get_sys_info():


### PR DESCRIPTION
Related: https://github.com/rasterio/rasterio/pull/2447