### PR TITLE
BUG: Fix WarpedVRT param cache in open_rasterio

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,7 @@ History
 
 Latest
 ------
-
+- BUG: Fix WarpedVRT param cache in :func:`rioxarray.open_rasterio` (issue #515)
 
 0.11.0
 ------

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -811,15 +811,15 @@ def open_rasterio(
         filename = vrt.src_dataset.name
         vrt_params = dict(
             src_crs=vrt.src_crs.to_string() if vrt.src_crs else None,
-            crs=vrt.crs.to_string() if vrt.crs else None,
+            crs=vrt.dst_crs.to_string() if vrt.dst_crs else None,
             resampling=vrt.resampling,
             tolerance=vrt.tolerance,
             src_nodata=vrt.src_nodata,
-            nodata=vrt.nodata,
-            width=vrt.width,
-            height=vrt.height,
+            nodata=vrt.dst_nodata,
+            width=vrt.dst_width,
+            height=vrt.dst_height,
             src_transform=vrt.src_transform,
-            transform=vrt.transform,
+            transform=vrt.dst_transform,
             dtype=vrt.working_dtype,
             warp_extras=vrt.warp_extras,
         )

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -38,6 +38,11 @@ from test.integration.test_integration_rioxarray import (
     _create_gdal_gcps,
 )
 
+cint_skip = pytest.mark.skipif(
+    rasterio.__version__ < "1.2.4",
+    reason="https://github.com/mapbox/rasterio/issues/2182",
+)
+
 
 @pytest.mark.parametrize(
     "subdataset, variable, group, match",
@@ -932,6 +937,19 @@ def test_rasterio_vrt_gcps(tmp_path):
                 )
 
 
+@cint_skip
+def test_rasterio_vrt_gcps__data_exists():
+    # https://github.com/corteva/rioxarray/issues/515
+    vrt_file = os.path.join(TEST_INPUT_DATA_DIR, "cint16.tif")
+    with rasterio.open(vrt_file) as src:
+        crs = src.gcps[1]
+        # NOTE: Eventually src_crs will not need to be provided
+        # https://github.com/mapbox/rasterio/pull/2193
+        with rasterio.vrt.WarpedVRT(src, src_crs=crs) as vrt:
+            rds = rioxarray.open_rasterio(vrt)
+            assert rds.values.any()
+
+
 @pytest.mark.parametrize("lock", [True, False])
 def test_open_cog(lock):
     cog_file = os.path.join(TEST_INPUT_DATA_DIR, "cog.tif")
@@ -1148,12 +1166,6 @@ def test_rotation_affine():
             ):
                 assert rioda.rio.transform(recalc=True) == rds.transform
             assert rioda.rio.resolution() == (10, 10)
-
-
-cint_skip = pytest.mark.skipif(
-    rasterio.__version__ < "1.2.4",
-    reason="https://github.com/mapbox/rasterio/issues/2182",
-)
 
 
 @cint_skip


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #515
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API


The input arguments don't match the properties on `WarpedVRT`