### PR TITLE
BUG: Always generate coordinates in rio.reproject when GCPS|RPCS present

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 Latest
 ------
 - BUG: Fix WarpedVRT param cache in :func:`rioxarray.open_rasterio` (issue #515)
+- BUG: Always generate coordinates in `rio.reproject` when GCPS|RPCS present (issue #517)
 
 0.11.0
 ------

--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -438,7 +438,8 @@ class RasterArray(XRasterBase):
         if gcps:
             kwargs.setdefault("gcps", gcps)
 
-        src_affine = None if "gcps" in kwargs else self.transform(recalc=True)
+        gcps_or_rpcs = "gcps" in kwargs or "rpcs" in kwargs
+        src_affine = None if gcps_or_rpcs else self.transform(recalc=True)
         if transform is None:
             dst_affine, dst_width, dst_height = _make_dst_affine(
                 self._obj, self.crs, dst_crs, resolution, shape, **kwargs
@@ -480,7 +481,13 @@ class RasterArray(XRasterBase):
         xda = xarray.DataArray(
             name=self._obj.name,
             data=dst_data,
-            coords=_make_coords(self._obj, dst_affine, dst_width, dst_height),
+            coords=_make_coords(
+                src_data_array=self._obj,
+                dst_affine=dst_affine,
+                dst_width=dst_width,
+                dst_height=dst_height,
+                force_generate=gcps_or_rpcs,
+            ),
             dims=tuple(dst_dims),
             attrs=new_attrs,
         )

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -1034,6 +1034,8 @@ def test_reproject__gcps_kwargs(tmp_path):
             2818720.0,
         )
     )
+    assert (rds.coords["x"].values > 11000).all()
+    assert (rds.coords["y"].values > 281700).all()
 
 
 def test_reproject_match(modis_reproject_match):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #517
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
