### PR TITLE
Revert "BUG: Fix subdatasets for specific Zarr driver scenario (#522)"

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,7 @@ History
 
 Latest
 ------
-- BUG: Fix subdatasets for specific Zarr driver scenario (issue #521)
+
 
 0.11.1
 ------

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -850,20 +850,8 @@ def open_rasterio(
         ):
             warnings.warn(str(rio_warning.message), type(rio_warning.message))  # type: ignore
 
-    # skip subdatasets for Zarr driver basic scenario
-    # https://github.com/corteva/rioxarray/issues/521
-    skip_subdatasets = (
-        riods.driver.lower() == "zarr"
-        and riods.crs is not None
-        and len(riods.subdatasets) == 2
-        and all(
-            subdataset.lower().endswith((":/x", ":/y"))
-            for subdataset in riods.subdatasets
-        )
-    )
-
     # open the subdatasets if they exist
-    if riods.subdatasets and not skip_subdatasets:
+    if riods.subdatasets:
         return _load_subdatasets(
             riods=riods,
             group=group,

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -1303,36 +1303,3 @@ def test_writing_gcps(tmp_path):
     with rioxarray.open_rasterio(tiffname2) as darr:
         assert "gcps" in darr.coords["spatial_ref"].attrs
         _check_rio_gcps(darr, *gdal_gcps)
-
-
-def test_zarr_driver_simple_dataset(tmp_path):
-    # https://github.com/corteva/rioxarray/issues/521
-    w_settings = {
-        "driver": "Zarr",
-        "dtype": "float32",
-        "nodata": -9999,
-        "width": 3039,
-        "height": 4501,
-        "count": 1,
-        "crs": 3857,
-        "transform": Affine(25.0, 0.0, 16556975.0, 0.0, -25.0, -4179000.0),
-        "blockxsize": 5760,
-        "blockysize": 5760,
-        "tiled": True,
-    }
-
-    zarr_settings = dict(
-        COMPRESS="BLOSC",
-        BLOCKSIZE="5760,5760",
-        BLOSC_CNAME="lz4",
-        BLOSC_CLEVEL=5,
-        BLOSC_SHUFFLE="BYTE",
-        BLOSC_NUM_THREADS="ALL_CPUS",
-        ARRAY_NAME="data",
-    )
-
-    output = tmp_path / "test.zarr"
-    with rasterio.open(output, "w", **w_settings, **zarr_settings) as dst:
-        dst.write(np.ones((4501, 3039), np.float32), 1)
-
-    assert isinstance(rioxarray.open_rasterio(output), xr.DataArray)


### PR DESCRIPTION
This reverts commit 595b69ce7c57a8eac339b0b35233d4e52ebad689.

As shown in https://github.com/OSGeo/gdal/pull/5706, there are scenarios where the assumptions made here could cause troubles. The fix for this is safest in GDAL.