### PR TITLE
MNT: corrections to setup.cfg; use "pytest"; add "make dist" target

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -148,7 +148,7 @@ jobs:
         shell: bash
         run: |
           source activate test
-          py.test --cov-report term-missing --cov=rioxarray --cov-report xml
+          pytest --cov-report term-missing --cov=rioxarray --cov-report xml
 
       - name: Test Build docs
         shell: bash
@@ -207,4 +207,4 @@ jobs:
         shell: bash
         run: |
           source activate test
-          py.test --cov-report term-missing --cov=rioxarray --cov-report xml
+          pytest --cov-report term-missing --cov=rioxarray --cov-report xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,11 +77,10 @@ jobs:
           python${{ matrix.python-version }} -m venv testenv
           . testenv/bin/activate
           python -m pip install --upgrade pip
-          python setup.py clean
           export INSTALL_DEPS='rasterio${{ matrix.rasterio-version }} xarray${{ matrix.xarray-version }}'
           [ "${{ matrix.run-with-scipy }}" = "YES" ] && export INSTALL_DEPS="${INSTALL_DEPS} scipy"
           python -m pip install $INSTALL_DEPS
-          python -m pip install -e .[dev,docs]
+          python -m pip install -e .[dev,doc]
 
       - name: run tests
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -232,4 +232,4 @@ jobs:
       - name: Check packages
         shell: bash
         run: |
-          twine check dist/*
+          twine check --strict dist/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         rev: 5.10.1
         hooks:
         -   id: isort
-            args: [setup.py, rioxarray/, test/, docs/]
+            args: [rioxarray/, test/, docs/]
     -   repo: https://github.com/asottile/blacken-docs
         rev: v1.12.1
         hooks:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -94,7 +94,7 @@ Using python::
 
 7. When you're done making changes, check that the tests pass::
 
-    $ py.test
+    $ pytest
 
 8. Commit your changes and push your branch to GitHub (this should trigger pre-commit checks)::
 
@@ -121,4 +121,4 @@ Tips
 
 To run a subset of tests::
 
-$ py.test test.test_rioxarray
+$ pytest test/unit/test_show_versions.py::test_get_main_info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,4 @@ recursive-exclude test *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
-recusive-prune docs/
+prune docs/

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ pylint:
 	pylint --load-plugins tests.linter --disable=I,E,W,R,C,F --enable C9999,C9998 tests/
 
 test: ## run tests quickly with the default Python
-	py.test
+	pytest
 
 docs: ## generate Sphinx HTML documentation, including API docs
 	# rm -f docs/rioxarray*.rst
@@ -80,12 +80,16 @@ docs-browser: docs ## generate Sphinx HTML documentation, including API docs
 	$(BROWSER) docs/_build/html/index.html
 
 release: dist ## package and upload a release
+	twine check --strict dist/*
 	twine upload dist/*
+
+dist: clean  ## builds source and wheel package
+	python -m build
 
 report: install-dev coverage ## clean, install development version, run all tests, produce coverage report
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	pip install .
 
 install-dev: clean ## install development version to active Python's site-packages
 	pip install -e .[all]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,13 @@
 author = rioxarray Contributors
 author_email = alansnow21@gmail.com
 name = rioxarray
+version = attr: rioxarray._version.__version__
 description = geospatial xarray extension powered by rasterio
 keywords = rioxarray, xarray, rasterio
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 license = Apache
-license_file = LICENSE
+license_files = LICENSE
 platform = any
 classifiers =
     Development Status :: 4 - Beta
@@ -72,6 +74,3 @@ all =
     %(doc)s
     %(test)s
     %(dev)s
-
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,5 @@
 """The setup script."""
-from pathlib import Path
 
 from setuptools import setup
 
-
-def get_version():
-    """
-    retreive rioxarray version information in version variable
-    (taken from pyproj)
-    """
-    with Path("rioxarray", "_version.py").open() as vfh:
-        for line in vfh:
-            if line.find("__version__") >= 0:
-                # parse __version__ and remove surrounding " or '
-                return line.split("=", maxsplit=2)[1].strip()[1:-1]
-    raise SystemExit("ERROR: rioxarray version not found.")
-
-
-setup(version=get_version())
+setup()


### PR DESCRIPTION
This PR is very similar to https://github.com/corteva/geocube/pull/111

- `setup.cfg`:
  - remove `bdist_universal` option
  - Use `license_files` to side-step warning in `python -m build`
  - Specify `long_description_content_type` to side-step warning in `twine check dist/*`
  - Add dynamic version from attribute
- `setup.py` is now a basic shim file, and does nothing custom; it might be removed at some point
- Use `pytest` command instead of `py.test` ([ref](https://stackoverflow.com/a/41893170/))
- Add `make dist` target, which was referenced in the Makefile
- Add `twine check --strict dist/*` before uploading release -- also `.whl` files could and should be uploaded to PyPI
- There is no "recusive-prune" option for MANIFEST.in -- just "prune"