### PR TITLE
Removed deprecated parameters from clip_box

### DIFF
--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -769,8 +769,6 @@ class RasterArray(XRasterBase):
                 right=np.array(right).item(),
                 top=np.array(top).item(),
                 transform=self.transform(recalc=True),
-                width=self.width,
-                height=self.height,
             )
             cl_array: xarray.DataArray = self.isel_window(window)  # type: ignore
         except rasterio.errors.WindowError as err:


### PR DESCRIPTION
Fixes https://github.com/corteva/rioxarray/issues/551 by removing unused parameters.