### PR TITLE
BUG: Fix reading cint16 files with dask

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 Latest
 ------
 - BUG: Fix reading file handle with dask (issue #550)
+- BUG: Fix reading cint16 files with dask (issue #542)
 
 0.11.1
 ------

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -680,7 +680,7 @@ def _prepare_dask(
         chunks = normalize_chunks(
             chunks=(1, "auto", "auto"),
             shape=(riods.count, riods.height, riods.width),
-            dtype=riods.dtypes[0],
+            dtype=_rasterio_to_numpy_dtype(riods.dtypes),
             previous_chunks=tuple((c,) for c in block_shape),
         )
     token = tokenize(filename, mtime, chunks)

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -1314,3 +1314,9 @@ def test_read_file_handle_with_dask():
         os.path.join(TEST_COMPARE_DATA_DIR, "small_dem_3m_merged.tif"), "rb"
     ) as src:
         rioxarray.open_rasterio(src, chunks=2048)
+
+
+@cint_skip
+def test_read_cint16_with_dask():
+    test_file = os.path.join(TEST_INPUT_DATA_DIR, "cint16.tif")
+    rioxarray.open_rasterio(test_file, chunks=True)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #542
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
