### PR TITLE
BUG: Ensure 'rio.bounds' ordered correctly

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,7 @@ Latest
 ------
 - BUG: Fix reading file handle with dask (issue #550)
 - BUG: Fix reading cint16 files with dask (issue #542)
+- BUG: Ensure `rio.bounds` ordered correctly (issue #545)
 
 0.11.1
 ------

--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -50,7 +50,12 @@ from rioxarray.raster_writer import (
     RasterioWriter,
     _ensure_nodata_dtype,
 )
-from rioxarray.rioxarray import XRasterBase, _get_data_var_message, _make_coords
+from rioxarray.rioxarray import (
+    XRasterBase,
+    _get_data_var_message,
+    _make_coords,
+    _order_bounds,
+)
 
 # DTYPE TO NODATA MAP
 # Based on: https://github.com/OSGeo/gdal/blob/
@@ -744,21 +749,17 @@ class RasterArray(XRasterBase):
                 f"{_get_data_var_message(self._obj)}"
             )
 
+        resolution_x, resolution_y = self.resolution()
         # make sure that if the coordinates are
         # in reverse order that it still works
-        resolution_x, resolution_y = self.resolution()
-        if resolution_y < 0:
-            top = maxy
-            bottom = miny
-        else:
-            top = miny
-            bottom = maxy
-        if resolution_x < 0:
-            left = maxx
-            right = minx
-        else:
-            left = minx
-            right = maxx
+        left, bottom, right, top = _order_bounds(
+            minx=minx,
+            miny=miny,
+            maxx=maxx,
+            maxy=maxy,
+            resolution_x=resolution_x,
+            resolution_y=resolution_y,
+        )
 
         # pull the data out
         window_error = None

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -2901,3 +2901,15 @@ def test_reproject__gcps_file(tmp_path):
             2818720.0,
         )
     )
+
+
+def test_bounds__ordered__dataarray():
+    xds = xarray.DataArray(
+        numpy.zeros((5, 5)), dims=("y", "x"), coords={"x": range(5), "y": range(5)}
+    )
+    assert xds.rio.bounds() == (-0.5, -0.5, 4.5, 4.5)
+
+
+def test_bounds__ordered__dataset():
+    xds = xarray.Dataset(None, coords={"x": range(5), "y": range(5)})
+    assert xds.rio.bounds() == (-0.5, -0.5, 4.5, 4.5)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #545
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
