### PR TITLE
DOC: add notes to docs that xarray.open_rasterio is deprecated

### DIFF
--- a/docs/getting_started/crs_management.ipynb
+++ b/docs/getting_started/crs_management.ipynb
@@ -46,7 +46,7 @@
     "1. Look in attributes (`attrs`) of your data array for the `grid_mapping` coordinate name.\n",
     "   Inside the `grid_mapping` coordinate first look for `spatial_ref` then `crs_wkt` and lastly the CF grid mapping attributes.\n",
     "   This is in line with the Climate and Forecast (CF) conventions for storing the CRS as well as GDAL netCDF conventions.\n",
-    "2. Look in the `crs` attribute and load in the CRS from there. This is for backwards compatibility with `xarray.open_rasterio`.      We recommend using `rioxarray.open_rasterio` instead.\n",
+    "2. Look in the `crs` attribute and load in the CRS from there. This is for backwards compatibility with `xarray.open_rasterio`, which is deprecated since version 0.20.0. We recommend using `rioxarray.open_rasterio` instead.\n",
     "\n",
     "The value for the `crs` is anything accepted by `rasterio.crs.CRS.from_user_input()`\n",
     "\n",

--- a/docs/getting_started/getting_started.rst
+++ b/docs/getting_started/getting_started.rst
@@ -70,6 +70,7 @@ Why use :func:`rioxarray.open_rasterio` instead of `xarray.open_rasterio`?
 4. It supports masking and scaling data with the `masked` and `mask_and_scale` kwargs.
 5. It adds the coordinate axis CF metadata.
 6. It loads raster metadata into the attributes.
+7. `xarray.open_rasterio` is deprecated (since v0.20.0)
 
 
 Introductory Information


### PR DESCRIPTION
For clarity, alert the user that `xarray.open_rasterio` is now deprecated and should not be used.