### PR TITLE
added band_as_variable option to open_rasterio

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -690,7 +690,7 @@ def _load_subdatasets(
             default_name=subdataset.split(":")[-1].lstrip("/").replace("/", "_"),
             decode_times=decode_times,
             decode_timedelta=decode_timedelta,
-            band_as_variable=False
+            band_as_variable=False,
             **open_kwargs,
         )
         if shape not in dim_groups:

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -30,6 +30,7 @@ from xarray.core.dataarray import DataArray
 from xarray.core.dtypes import maybe_promote
 from xarray.core.utils import is_scalar
 from xarray.core.variable import as_variable
+import pyproj
 
 from rioxarray.exceptions import RioXarrayError
 from rioxarray.rioxarray import _generate_spatial_coords

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -991,7 +991,7 @@ def open_rasterio(
             spatial_ref_attrs = pyproj.CRS.from_user_input(riods.crs).to_cf()
             data_vars["spatial_ref"] = ((), 0, spatial_ref_attrs)
             
-            coords = xr.Dataset(data_vars=data_vars)
+            coords = Dataset(data_vars=data_vars)
         else:
             coords[coord_name] = np.asarray(riods.indexes)
 


### PR DESCRIPTION
First draft of a possible implementation of `read_variable_as_bands`.
@snowman2 what do you think? Is it too naive as an approach?

```python
import rioxarray

print(rioxarray.open_rasterio('./results/S2_L2A_data_mod.tiff',band_as_variable=True))
```
```
<xarray.DataArray (band: 3, y: 240, x: 626)>
[450720 values with dtype=uint16]
Coordinates:
  * band         (band) <U3 'B02' 'B03' 'B04'
  * x            (x) float64 6.609e+05 6.609e+05 ... 6.671e+05 6.671e+05
  * y            (y) float64 5.104e+06 5.104e+06 ... 5.102e+06 5.102e+06
    spatial_ref  int64 0
Attributes:
    AREA_OR_POINT:        Area
    PROCESSING_SOFTWARE:  0.6.4a1
    DESCRIPTION:          B02
    _FillValue:           0
    scale_factor:         1.0
    add_offset:           0.0
    long_name:            ('B02', 'B03', 'B04')
```



 - [ ] Closes [#296]
 - [ ] Tests added
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
