### PR TITLE
TYPE: Use explicit optional

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -934,7 +934,7 @@ def open_rasterio(
     parse_coordinates: Optional[bool] = None,
     chunks: Optional[Union[int, Tuple, Dict]] = None,
     cache: Optional[bool] = None,
-    lock: Any = None,
+    lock: Optional[Any] = None,
     masked: bool = False,
     mask_and_scale: bool = False,
     variable: Optional[Union[str, List[str], Tuple[str, ...]]] = None,

--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -724,7 +724,7 @@ class RasterArray(XRasterBase):
         maxy: float,
         auto_expand: Union[bool, int] = False,
         auto_expand_limit: int = 3,
-        crs: Any = None,
+        crs: Optional[Any] = None,
     ) -> xarray.DataArray:
         """Clip the :obj:`xarray.DataArray` by a bounding box.
 
@@ -845,7 +845,7 @@ class RasterArray(XRasterBase):
     def clip(
         self,
         geometries: Iterable,
-        crs: Any = None,
+        crs: Optional[Any] = None,
         all_touched: bool = False,
         drop: bool = True,
         invert: bool = False,
@@ -1051,9 +1051,9 @@ class RasterArray(XRasterBase):
     def to_raster(
         self,
         raster_path: Union[str, os.PathLike],
-        driver: str = None,
-        dtype: Union[str, np.dtype] = None,
-        tags: Dict[str, str] = None,
+        driver: Optional[str] = None,
+        dtype: Optional[Union[str, np.dtype]] = None,
+        tags: Optional[Dict[str, str]] = None,
         windowed: bool = False,
         recalc_transform: bool = True,
         lock: Optional[bool] = None,

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -252,7 +252,7 @@ class RasterDataset(XRasterBase):
         maxy: float,
         auto_expand: Union[bool, int] = False,
         auto_expand_limit: int = 3,
-        crs: Any = None,
+        crs: Optional[Any] = None,
     ) -> xarray.Dataset:
         """Clip the :class:`xarray.Dataset` by a bounding box in dimensions 'x'/'y'.
 
@@ -314,7 +314,7 @@ class RasterDataset(XRasterBase):
     def clip(
         self,
         geometries: Iterable,
-        crs: Any = None,
+        crs: Optional[Any] = None,
         all_touched: bool = False,
         drop: bool = True,
         invert: bool = False,
@@ -440,9 +440,9 @@ class RasterDataset(XRasterBase):
     def to_raster(
         self,
         raster_path: Union[str, os.PathLike],
-        driver: str = None,
-        dtype: Union[str, np.dtype] = None,
-        tags: Dict[str, str] = None,
+        driver: Optional[str] = None,
+        dtype: Optional[Union[str, np.dtype]] = None,
+        tags: Optional[Dict[str, str]] = None,
         windowed: bool = False,
         recalc_transform: bool = True,
         lock: Optional[bool] = None,

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -435,8 +435,8 @@ class XRasterBase:
 
     def write_crs(
         self,
-        input_crs: Any = None,
-        grid_mapping_name: str = None,
+        input_crs: Optional[Any] = None,
+        grid_mapping_name: Optional[str] = None,
         inplace: bool = False,
     ) -> Union[xarray.Dataset, xarray.DataArray]:
         """
@@ -1197,7 +1197,7 @@ class XRasterBase:
         self,
         gcps: Iterable[GroundControlPoint],
         gcp_crs: Any,
-        grid_mapping_name: str = None,
+        grid_mapping_name: Optional[str] = None,
         inplace: bool = False,
     ) -> Union[xarray.Dataset, xarray.DataArray]:
         """


### PR DESCRIPTION
```
note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
```

https://peps.python.org/pep-0484/

>  Type checkers should move towards requiring the optional type to be made explicit.