### PR TITLE
MNT: Add dockerfile for running tests with different GDAL versions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -105,6 +105,27 @@ Using python::
 9. Submit a pull request through the GitHub website.
 
 
+Running tests with docker
+-------------------------
+
+This assumes you have cloned the rioxarray repository and are in the base folder.
+
+1. Build the docker image
+
+.. code-block:: bash
+
+    docker build -t rioxarray .
+
+2. Run the tests
+
+.. code-block:: bash
+
+    docker run --rm \
+        -v $PWD/test/:/app/test \
+        -t rioxarray \
+        'source /venv/bin/activate && python -m pytest'
+
+
 Pull Request Guidelines
 -----------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+ARG GDAL=ubuntu-full-3.6.1
+FROM osgeo/gdal:${GDAL}
+ARG PYTHON_VERSION="3.8"
+ENV LANG="C.UTF-8"
+ENV LC_ALL="C.UTF-8"
+ENV PIP_NO_BINARY="rasterio"
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository -y ppa:deadsnakes/ppa
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    g++ \
+    gdb \
+    make \
+    python3-pip \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-dev \
+    python${PYTHON_VERSION}-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+ADD . /app
+RUN python${PYTHON_VERSION} -m venv /venv && \
+    /venv/bin/python -m pip install -U pip && \
+    /venv/bin/python -m pip install -e .[dev,doc,test]
+ENTRYPOINT ["/bin/bash", "-c"]


### PR DESCRIPTION
Found this to be useful recently with updating GDAL 3.6.1 tests.