### PR TITLE
DOC: Fix typo in docstring of `.clip()`

### DIFF
--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -879,7 +879,7 @@ class RasterArray(XRasterBase):
         Parameters
         ----------
         geometries: Iterable
-            A list of geojson geometry dicts or objects with __geom_interface__ with
+            A list of geojson geometry dicts or objects with __geo_interface__ with
             if you have rasterio 1.2+.
         crs: :obj:`rasterio.crs.CRS`, optional
             The CRS of the input geometries. Default is to assume it is the same


### PR DESCRIPTION
This confused me for a sec, thought I'd open a quick fix right away ;)