### PR TITLE
DOC: Document grid_mapping in encoding

### DIFF
--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -395,7 +395,7 @@ class XRasterBase:
         self, grid_mapping_name: str = DEFAULT_GRID_MAP, inplace: bool = False
     ) -> Union[xarray.Dataset, xarray.DataArray]:
         """
-        Write the CF grid_mapping attribute.
+        Write the CF grid_mapping attribute to the encoding.
 
         Parameters
         ----------
@@ -441,6 +441,8 @@ class XRasterBase:
     ) -> Union[xarray.Dataset, xarray.DataArray]:
         """
         Write the CRS to the dataset in a CF compliant manner.
+
+        .. warning:: The grid_mapping attribute is written to the encoding.
 
         Parameters
         ----------


### PR DESCRIPTION
I think there should be some more documentation about writing the grid_mapping to the encoding, for example to avoid the following issue: ds.to_netcdf(path, encoding=encoding) overwrites the grid_mapping encoding and results in incomplete CRS information (results in a NetCDF for which the CRS is not automatically recognized by QGIS, for example). Probably this is commonly used to set compression (accepted answer to https://stackoverflow.com/questions/40766037/specify-encoding-compression-for-many-variables-in-xarray-dataset-when-write-to).

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
