### PR TITLE
Depend on numpy>=1.21 to fix installation issue

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- DEP: pin numpy>=1.21 (pull #636)
 
 0.13.3
 ------

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     rasterio>=1.1.1
     xarray>=0.17
     pyproj>=2.2
+    numpy>=1.21
 
 [options.package_data]
 rioxarray =


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #587
 - [ ] ~~Tests added~~ Not sure how to write a test for an installation. Checks out locally with poetry though.
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
