### PR TITLE
BUG: Fix usage of encode_cf_variable in rio.to_raster

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,7 @@ Latest
 - DEP: Drop Python 3.8 support (issue #582)
 - DEP: pin rasterio>=1.2 (pull #642)
 - BUG: Fix WarpedVRT in :func:`rioxarray.open_rasterio` when band_as_variable=True (issue #644)
+- BUG: Fix usage of `encode_cf_variable` in `rio.to_raster` (pull #652)
 
 0.13.4
 ------

--- a/rioxarray/raster_writer.py
+++ b/rioxarray/raster_writer.py
@@ -285,7 +285,9 @@ class RasterioWriter:
                         out_data = xarray_dataarray.rio.isel_window(window)
                     else:
                         out_data = xarray_dataarray
-                    data = encode_cf_variable(out_data).values.astype(numpy_dtype)
+                    data = encode_cf_variable(out_data.variable).values.astype(
+                        numpy_dtype
+                    )
                     if data.ndim == 2:
                         rds.write(data, 1, window=window)
                     else:
@@ -293,7 +295,7 @@ class RasterioWriter:
 
         if lock and is_dask_collection(xarray_dataarray.data):
             return dask.array.store(
-                encode_cf_variable(xarray_dataarray).data.astype(numpy_dtype),
+                encode_cf_variable(xarray_dataarray.variable).data.astype(numpy_dtype),
                 self,
                 lock=lock,
                 compute=compute,


### PR DESCRIPTION
 - [x] Related: https://github.com/pydata/xarray/issues/7645
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
