### PR TITLE
BUG: Fix merge crs check

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- BUG: Fix :mod:`rioxarray.merge` CRS check
 
 0.14.0
 ------

--- a/rioxarray/merge.py
+++ b/rioxarray/merge.py
@@ -25,6 +25,7 @@ class RasterioDatasetDuck:
 
     def __init__(self, xds: DataArray):
         self._xds = xds
+        self.crs = xds.rio.crs
         self.bounds = xds.rio.bounds(recalc=True)
         self.count = int(xds.rio.count)
         self.dtypes = [xds.dtype]


### PR DESCRIPTION
Related: https://github.com/rasterio/rasterio/pull/2740

https://github.com/corteva/rioxarray/actions/runs/4470278171/jobs/7853603260

```
FAILED test/integration/test_integration_merge.py::test_merge_arrays[True] - AttributeError: 'RasterioDatasetDuck' object has no attribute 'crs'
FAILED test/integration/test_integration_merge.py::test_merge_arrays[False] - AttributeError: 'RasterioDatasetDuck' object has no attribute 'crs'
FAILED test/integration/test_integration_merge.py::test_merge__different_crs[True] - AttributeError: 'RasterioDatasetDuck' object has no attribute 'crs'
FAILED test/integration/test_integration_merge.py::test_merge__different_crs[False] - AttributeError: 'RasterioDatasetDuck' object has no attribute 'crs'
FAILED test/integration/test_integration_merge.py::test_merge_arrays__res - AttributeError: 'RasterioDatasetDuck' object has no attribute 'crs'
FAILED test/integration/test_integration_merge.py::test_merge_datasets - AttributeError: 'RasterioDatasetDuck' object has no attribute 'crs'
FAILED test/integration/test_integration_merge.py::test_merge_datasets__res - AttributeError: 'RasterioDatasetDuck' object has no attribute 'crs'
```