### PR TITLE
DOC: Update link to "Extending xarray" in "getting_started.rst"

### DIFF
--- a/docs/getting_started/getting_started.rst
+++ b/docs/getting_started/getting_started.rst
@@ -8,7 +8,7 @@ Welcome! This page aims to help you gain a foundational understanding of rioxarr
 rio accessor
 -------------
 
-rioxarray `extends xarray <http://xarray.pydata.org/en/stable/internals.html#extending-xarray>`__
+rioxarray `extends xarray <https://docs.xarray.dev/en/stable/internals/extending-xarray.html>`__
 with the `rio` accessor. The `rio` accessor is activated by importing rioxarray like so:
 
 .. code-block:: python


### PR DESCRIPTION
It seems like the link to "Extending xarray" has changed from http://xarray.pydata.org/en/stable/internals.html#extending-xarray (this link gives a 404 error page) to https://docs.xarray.dev/en/stable/internals/extending-xarray.html. This PR aims to update this in the file [`getting_started.rst`](https://github.com/corteva/rioxarray/blob/master/docs/getting_started/getting_started.rst).
