### PR TITLE
ENH: Pass on on-disk chunk sizes as preferred chunk sizes to the xarray backend

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 Latest
 ------
 - BUG: Fix setting spatial dims internally during propagation (pull #682)
+- ENH: Pass on on-disk chunk sizes as preferred chunk sizes to the xarray backend (pull #678)
 
 0.14.1
 ------

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -1264,7 +1264,7 @@ def open_rasterio(
         result = _prepare_dask(result, riods, filename, chunks)
 
     result.encoding["preferred_chunks"] = {
-        "y": riods.block_shapes[0][0],
+        riods.rio.y_dim: riods.block_shapes[0][0],
         "x": riods.block_shapes[0][1],
         coord_name: 1,
     }

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -1264,9 +1264,11 @@ def open_rasterio(
     if chunks is not None:
         result = _prepare_dask(result, riods, filename, chunks)
 
-    result.encoding["preferred_chunks"] = {"y": riods.block_shapes[0][0],
-                                           "x": riods.block_shapes[0][1],
-                                           coord_name: 1}
+    result.encoding["preferred_chunks"] = {
+        "y": riods.block_shapes[0][0],
+        "x": riods.block_shapes[0][1],
+        coord_name: 1,
+    }
 
     # add file path to encoding
     result.encoding["source"] = riods.name

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -924,6 +924,7 @@ def _prepare_dask(
             dtype=_rasterio_to_numpy_dtype(riods.dtypes),
             previous_chunks=tuple((c,) for c in block_shape),
         )
+        breakpoint()
     token = tokenize(filename, mtime, chunks)
     name_prefix = f"open_rasterio-{token}"
     return result.chunk(chunks, name_prefix=name_prefix, token=token)
@@ -1236,7 +1237,7 @@ def open_rasterio(
     )
     result.encoding = encoding
 
-    # update attributes from NetCDF attributess
+    # update attributes from NetCDF attributes
     _load_netcdf_attrs(riods.tags(), result)
     result = _decode_datetime_cf(
         result, decode_times=decode_times, decode_timedelta=decode_timedelta
@@ -1262,6 +1263,10 @@ def open_rasterio(
 
     if chunks is not None:
         result = _prepare_dask(result, riods, filename, chunks)
+
+    result.encoding["preferred_chunks"] = {"y": riods.block_shapes[0][0],
+                                           "x": riods.block_shapes[0][1],
+                                           coord_name: 1}
 
     # add file path to encoding
     result.encoding["source"] = riods.name

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -1262,12 +1262,12 @@ def open_rasterio(
 
     if chunks is not None:
         result = _prepare_dask(result, riods, filename, chunks)
-
-    result.encoding["preferred_chunks"] = {
-        riods.rio.y_dim: riods.block_shapes[0][0],
-        "x": riods.block_shapes[0][1],
-        coord_name: 1,
-    }
+    else:
+        result.encoding["preferred_chunks"] = {
+            result.rio.y_dim: riods.block_shapes[0][0],
+            result.rio.x_dim: riods.block_shapes[0][1],
+            coord_name: 1,
+        }
 
     # add file path to encoding
     result.encoding["source"] = riods.name

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -924,7 +924,6 @@ def _prepare_dask(
             dtype=_rasterio_to_numpy_dtype(riods.dtypes),
             previous_chunks=tuple((c,) for c in block_shape),
         )
-        breakpoint()
     token = tokenize(filename, mtime, chunks)
     name_prefix = f"open_rasterio-{token}"
     return result.chunk(chunks, name_prefix=name_prefix, token=token)

--- a/rioxarray/xarray_plugin.py
+++ b/rioxarray/xarray_plugin.py
@@ -38,8 +38,6 @@ class RasterioBackend(xarray.backends.common.BackendEntrypoint):
         filename_or_obj,
         drop_variables=None,
         parse_coordinates=None,
-        chunks=None,
-        cache=None,
         lock=None,
         masked=False,
         mask_and_scale=True,
@@ -53,6 +51,8 @@ class RasterioBackend(xarray.backends.common.BackendEntrypoint):
     ):
         if open_kwargs is None:
             open_kwargs = {}
+        chunks = {}
+        cache = None
         rds = _io.open_rasterio(
             filename_or_obj,
             parse_coordinates=parse_coordinates,

--- a/rioxarray/xarray_plugin.py
+++ b/rioxarray/xarray_plugin.py
@@ -51,7 +51,7 @@ class RasterioBackend(xarray.backends.common.BackendEntrypoint):
     ):
         if open_kwargs is None:
             open_kwargs = {}
-        chunks = {}
+        chunks = None
         cache = None
         rds = _io.open_rasterio(
             filename_or_obj,

--- a/rioxarray/xarray_plugin.py
+++ b/rioxarray/xarray_plugin.py
@@ -51,13 +51,10 @@ class RasterioBackend(xarray.backends.common.BackendEntrypoint):
     ):
         if open_kwargs is None:
             open_kwargs = {}
-        chunks = None
-        cache = None
         rds = _io.open_rasterio(
             filename_or_obj,
             parse_coordinates=parse_coordinates,
-            chunks=chunks,
-            cache=cache,
+            cache=False,
             lock=lock,
             masked=masked,
             mask_and_scale=mask_and_scale,

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -313,6 +313,7 @@ def test_open_rasterio_mask_chunk_clip():
             "grid_mapping": "spatial_ref",
             "dtype": "uint16",
             "rasterio_dtype": "uint16",
+            "preferred_chunks": {"band": 1, "x": 574, "y": 7},
         }
         attrs = dict(xdi.attrs)
         assert_almost_equal(
@@ -356,6 +357,7 @@ def test_open_rasterio_mask_chunk_clip():
             "grid_mapping": "spatial_ref",
             "dtype": "uint16",
             "rasterio_dtype": "uint16",
+            "preferred_chunks": {"band": 1, "x": 574, "y": 7},
         }
 
         # test dataset
@@ -371,6 +373,7 @@ def test_open_rasterio_mask_chunk_clip():
             "grid_mapping": "spatial_ref",
             "dtype": "uint16",
             "rasterio_dtype": "uint16",
+            "preferred_chunks": {"band": 1, "x": 574, "y": 7},
         }
 
 
@@ -1121,6 +1124,7 @@ def test_mask_and_scale(open_rasterio):
             "grid_mapping": "crs",
             "dtype": "uint16",
             "rasterio_dtype": "uint16",
+            "preferred_chunks": dict(band=1, x=1386, y=585),
         }
         attrs = rds.air_temperature.attrs
         assert "_Unsigned" not in attrs
@@ -1146,6 +1150,7 @@ def test_no_mask_and_scale(open_rasterio):
             "grid_mapping": "crs",
             "dtype": "uint16",
             "rasterio_dtype": "uint16",
+            "preferred_chunks": {"band": 1, "x": 1386, "y": 585},
         }
         attrs = rds.air_temperature.attrs
         assert attrs["_Unsigned"] == "true"

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -313,7 +313,6 @@ def test_open_rasterio_mask_chunk_clip():
             "grid_mapping": "spatial_ref",
             "dtype": "uint16",
             "rasterio_dtype": "uint16",
-            "preferred_chunks": {"band": 1, "x": 574, "y": 7},
         }
         attrs = dict(xdi.attrs)
         assert_almost_equal(
@@ -357,7 +356,6 @@ def test_open_rasterio_mask_chunk_clip():
             "grid_mapping": "spatial_ref",
             "dtype": "uint16",
             "rasterio_dtype": "uint16",
-            "preferred_chunks": {"band": 1, "x": 574, "y": 7},
         }
 
         # test dataset
@@ -373,7 +371,6 @@ def test_open_rasterio_mask_chunk_clip():
             "grid_mapping": "spatial_ref",
             "dtype": "uint16",
             "rasterio_dtype": "uint16",
-            "preferred_chunks": {"band": 1, "x": 574, "y": 7},
         }
 
 

--- a/test/integration/test_integration_xarray_plugin.py
+++ b/test/integration/test_integration_xarray_plugin.py
@@ -20,6 +20,7 @@ def test_xarray_open_dataset():
     assert "spatial_ref" in ds.coords
     assert "grid_mapping" not in ds.data_vars["band_data"].attrs
     assert "grid_mapping" in ds.data_vars["band_data"].encoding
+    assert "preferred_chunks" in ds.data_vars["band_data"].encoding
 
     ds = xarray.open_dataset(cog_file)
 


### PR DESCRIPTION
This PR proposes a removes the (unused) `chunks` and `cache` argument from the `open_dataset` plugin function and sends values to `open_rasterio` to get a result inline with what xarray expects. Moreover, the `preferred_chunks` encoding attribute is populated for xarray to be able to do optimized automated chunking.

The fact that `chunks` and `cache` are ignored by xarray is documented in the example here: https://docs.xarray.dev/en/stable/internals/how-to-add-new-backend.html#backendentrypoint-subclassing
And the recommended usage of `preferred_chunks` is documented here: https://docs.xarray.dev/en/stable/internals/how-to-add-new-backend.html#preferred-chunk-sizes

Finally, I wasn't really sure how/where to put the tests, what do you recommend?

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
