### PR TITLE
LNT: Update isort pre-commit link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
         rev: 22.10.0
         hooks:
         -   id: black
-    -   repo: https://github.com/timothycrosley/isort
-        rev: 5.10.1
-        hooks:
-        -   id: isort
-            args: [rioxarray/, test/, docs/]
+    - repo: https://github.com/pycqa/isort
+      rev: 5.12.0
+      hooks:
+      - id: isort
+        args: [rioxarray/, test/, docs/]
     -   repo: https://github.com/asottile/blacken-docs
         rev: v1.12.1
         hooks:


### PR DESCRIPTION
The pre-commit link for isort was deprecated. This PR fixes it.

