### PR TITLE
CI: don't fetch appache-arrow repo

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Remove unused apt repo
+        if: ${{ matrix.gdal-version }} == '3.5.3'
+        run: |
+          rm -f /etc/apt/sources.list.d/apache-arrow.sources
+
       - name: Update
         run: |
           apt-get update


### PR DESCRIPTION
In GDAL 3.5.3 docker repo keys for appach-arrow are stale, this will probably be fixed by rebuilding that docker image. For now we can just remove that repo before running update.

extracting build fix into a separate PR from #683 .