### PR TITLE
DEP: Support Python 3.10-3.12

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Conda
         uses: s-weigand/setup-conda@v1
         with:
-          python-version: 3.9
+          python-version: '3.10'
           conda-channels: conda-forge
 
       - name: Install and Build
@@ -31,7 +31,7 @@ jobs:
         run: |
           conda config --prepend channels conda-forge
           conda config --set channel_priority strict
-          conda create -n docs python=3.9 rasterio xarray scipy pyproj pandoc
+          conda create -n docs python=3.10 rasterio xarray scipy pyproj pandoc
           source activate docs
           python -m pip install -e .[doc]
           sphinx-build -b html docs/ docs/_build/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,26 +32,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         rasterio-version: ['']
         xarray-version: ['']
         pandas-version: ['']
         run-with-scipy: ['YES']
         gdal-version: ['3.6.4']
         include:
-          - python-version: '3.9'
+          - python-version: '3.10'
             rasterio-version: ''
             xarray-version: '==0.17'
             pandas-version: '<2'
             run-with-scipy: 'YES'
             gdal-version: '3.4.3'
-          - python-version: '3.9'
-            rasterio-version: '==1.2.1'
-            xarray-version: ''
-            pandas-version: ''
-            run-with-scipy: 'YES'
-            gdal-version: '3.5.3'
-          - python-version: '3.9'
+          - python-version: '3.10'
             rasterio-version: ''
             xarray-version: ''
             pandas-version: ''
@@ -108,7 +102,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         rasterio-version: ['*']
         xarray-version: ['*']
         run-with-scipy: ['YES']
@@ -142,7 +136,7 @@ jobs:
           conda info
 
       - name: pylint
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         shell: bash
         run: |
           source activate test
@@ -150,7 +144,7 @@ jobs:
 
       - name: mypy
         shell: bash
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         run: |
           source activate test
           mypy rioxarray/
@@ -181,7 +175,7 @@ jobs:
       - name: Setup Conda
         uses: s-weigand/setup-conda@v1
         with:
-          python-version: 3.9
+          python-version: '3.10'
           conda-channels: conda-forge
 
       - name: Install Env
@@ -189,7 +183,7 @@ jobs:
         run: |
           conda config --prepend channels conda-forge
           conda config --set channel_priority strict
-          conda create -n test python=3.9 proj libgdal cython netcdf4
+          conda create -n test python=3.10 proj libgdal cython netcdf4
           source activate test
           python -m pip install \
             --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -135,7 +135,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.9-3.11.
+3. The pull request should work for Python 3.10-3.12.
 
 Tips
 ----

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GDAL=ubuntu-full-3.6.4
 FROM ghcr.io/osgeo/gdal:${GDAL}
-ARG PYTHON_VERSION="3.9"
+ARG PYTHON_VERSION="3.10"
 ENV LANG="C.UTF-8"
 ENV LC_ALL="C.UTF-8"
 ENV PIP_NO_BINARY="rasterio"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 
 environment:
   matrix:
-    - PYTHON_VERSION: "3.9"
+    - PYTHON_VERSION: "3.10"
       MINICONDA: "C:\\Miniconda3-x64"
 
 install:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 
 [mypy-affine]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ classifiers =
     Operating System :: OS Independent
     Topic :: Scientific/Engineering :: GIS
     Programming Language :: Python
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3
     Topic :: Software Development :: Libraries :: Python Modules
     Typing :: Typed
@@ -30,7 +30,7 @@ download_url = http://python.org/pypi/rioxarray
 packages = find:
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     packaging
     rasterio>=1.2


### PR DESCRIPTION
Python 3.9 is no longer supported in the scientific python ecosystem: https://scientific-python.org/specs/spec-0000/