### PR TITLE
Avoiding DeprecationWarning: xr.Dataset.drop() -> xr.Dataset.drop_vars()

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -881,7 +881,7 @@ def _load_bands_as_variables(
                 **open_kwargs,
             )
             .squeeze()  # type: ignore
-            .drop("band")  # type: ignore
+            .drop_vars("band")  # type: ignore
         )
     dataset = Dataset(data_vars, attrs=global_tags)
 


### PR DESCRIPTION
Very simple PR. I was getting deprecation warnings from `rioxarray` that originated in `xarray`. Here is an example of the warning:

```
  /home/xavier/.pyenv/versions/3.9.7/envs/vetl_s2/lib/python3.9/site-packages/rioxarray/_io.py:870: DeprecationWarning: dropping variables using `drop` is deprecated; use drop_vars.
    open_rasterio(  # type: ignore
```

So I simply went in and changed it. I don't have time to recreate the full dev environment, but it should work. That said, maybe someone should probably re-run you're test suite before merging. I can do it, but most likely a few days from now.
