### PR TITLE
BUG: Add decode_coords kwarg to backend entrypoint

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,8 @@ History
 
 Latest
 ------
+- BUG: Add decode_coords kwarg to backend entrypoint (pull #763)
+
 
 0.15.1
 -------

--- a/rioxarray/xarray_plugin.py
+++ b/rioxarray/xarray_plugin.py
@@ -45,11 +45,14 @@ class RasterioBackend(xarray.backends.common.BackendEntrypoint):
         variable=None,
         group=None,
         default_name="band_data",
+        decode_coords="all",
         decode_times=True,
         decode_timedelta=None,
         band_as_variable=False,
         open_kwargs=None,
     ):
+        if decode_coords != "all":
+            raise RioXarrayError("Only 'all' is supported for 'decode_coords'.")
         if open_kwargs is None:
             open_kwargs = {}
         rds = _io.open_rasterio(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,5 @@
 import os
+from functools import partial
 
 import pytest
 import rasterio
@@ -102,9 +103,7 @@ def _assert_xarrays_equal(
             assert unwanted_attr not in input_xarray.attrs
 
 
-def open_rasterio_engine(file_name_or_object, **kwargs):
-    xarray = pytest.importorskip("xarray", minversion="0.18")
-    return xarray.open_dataset(file_name_or_object, engine="rasterio", **kwargs)
+open_rasterio_engine = partial(xarray.open_dataset, engine="rasterio")
 
 
 @pytest.fixture(

--- a/test/integration/test_integration_xarray_plugin.py
+++ b/test/integration/test_integration_xarray_plugin.py
@@ -8,10 +8,12 @@ from test.conftest import TEST_INPUT_DATA_DIR
 xarray = pytest.importorskip("xarray", minversion="0.18")
 
 
-def test_xarray_open_dataset():
+@pytest.mark.parametrize(
+    "kwargs", [{}, {"engine": "rasterio"}, {"decode_coords": "all"}]
+)
+def test_xarray_open_dataset(kwargs):
     cog_file = os.path.join(TEST_INPUT_DATA_DIR, "cog.tif")
-
-    ds = xarray.open_dataset(cog_file, engine="rasterio")
+    ds = xarray.open_dataset(cog_file, **kwargs)
 
     assert isinstance(ds, xarray.Dataset)
     assert "band_data" in ds.data_vars
@@ -21,10 +23,6 @@ def test_xarray_open_dataset():
     assert "grid_mapping" not in ds.data_vars["band_data"].attrs
     assert "grid_mapping" in ds.data_vars["band_data"].encoding
     assert "preferred_chunks" in ds.data_vars["band_data"].encoding
-
-    ds = xarray.open_dataset(cog_file)
-
-    assert isinstance(ds, xarray.Dataset)
 
 
 def test_xarray_open_dataset__drop_variables():
@@ -66,3 +64,9 @@ def test_open_multiple_resolution():
             engine="rasterio",
             drop_variables="QC_500m_1",
         )
+
+
+def test_xarray_open_dataset__invalid_decode_coords():
+    cog_file = os.path.join(TEST_INPUT_DATA_DIR, "cog.tif")
+    with pytest.raises(RioXarrayError):
+        xarray.open_dataset(cog_file, decode_coords=False)


### PR DESCRIPTION
Adding to enable compatibility in `xarray.open_dataset` with other engines that require the kwarg:

```
TypeError: RasterioBackend.open_dataset() got an unexpected keyword argument 'decode_coords'
```