### PR TITLE
BUG:reproject_match: Remove setting spatial dims on output dataset

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- BUG:reproject_match: Remove setting spatial dims on output resampled dataset (issue #768)
 
 0.15.3
 ------

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -188,9 +188,7 @@ class RasterDataset(XRasterBase):
                 ):
                     raise
                 resampled_dataset[var] = self._obj[var].copy()
-        return resampled_dataset.rio.set_spatial_dims(
-            x_dim=self.x_dim, y_dim=self.y_dim, inplace=True
-        )
+        return resampled_dataset
 
     def pad_box(
         self,

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -781,6 +781,28 @@ def test_reproject_match__non_geospatial(dummy_dataset_non_geospatial):
         assert "non_geo_stuff" in ds_reproject.data_vars
 
 
+def test_reproject_match__geographic_dataset():
+    lat = [0.1, 0.15, 0.2]
+    lon = [0.1, 0.15, 0.2]
+    data = numpy.arange(1, 10).reshape(3, 3)
+    ds = xarray.Dataset(
+        data_vars={
+            "foo": (["lat", "lon"], data),
+            "bar": (["lat", "lon"], data),
+        },
+        coords={"lat": lat, "lon": lon},
+    )
+
+    ds = (
+        ds.rio.write_crs(4326, inplace=True)
+        .rio.set_spatial_dims(x_dim="lon", y_dim="lat", inplace=True)
+        .rio.write_coordinate_system(inplace=True)
+    )
+    ds_match = ds.rio.reproject_match(ds)
+    assert_almost_equal(ds_match.x.values, ds.lon.values)
+    assert_almost_equal(ds_match.y.values, ds.lat.values)
+
+
 def test_interpolate_na__non_geospatial(dummy_dataset_non_geospatial):
     pytest.importorskip("scipy")
     ds = dummy_dataset_non_geospatial


### PR DESCRIPTION
 - [x] Closes #768
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
