### PR TITLE
TST: Add cftime dependency

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
+cftime
+dask
+netcdf4
 pytest>=3.6
 pytest-cov
 pytest-timeout
-dask
-netcdf4


### PR DESCRIPTION
Related: https://github.com/Unidata/cftime/issues/318

```
  File "/usr/share/miniconda/envs/test/lib/python3.10/site-packages/xarray/core/common.py", line 26, in <module>
    import cftime
  File "/usr/share/miniconda/envs/test/lib/python3.10/site-packages/cftime/__init__.py", line 1, in <module>
    from ._cftime import (datetime, real_datetime,

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.1.0.dev0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```