### PR TITLE
BUG: Raise overflow error when nodata conversion is unsafe

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- BUG: Raise OverflowError when nodata data type conversion is unsafe (pull #782)
 
 0.15.5
 ------


### PR DESCRIPTION
Changing to be consistent with Numpy 2: https://numpy.org/neps/nep-0050-scalar-promotion.html