### PR TITLE
BUG: Support writing GCPs to netCDF

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 Latest
 ------
 - BUG: Raise OverflowError when nodata data type conversion is unsafe (pull #782)
+- BUG: Support writing GCPs to netCDF (issue #778)
 
 0.15.5
 ------

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -2987,7 +2987,7 @@ def _check_rio_gcps(darr, src_gcps, crs):
     assert "y" not in darr.coords
     assert darr.rio.crs == crs
     assert "gcps" in darr.spatial_ref.attrs
-    gcps = darr.spatial_ref.attrs["gcps"]
+    gcps = json.loads(darr.spatial_ref.attrs["gcps"])
     assert gcps["type"] == "FeatureCollection"
     assert len(gcps["features"]) == len(src_gcps)
     for feature, gcp in zip(gcps["features"], src_gcps):


### PR DESCRIPTION
 - [x] Closes #778
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

Note: No need to be backwards compatible because writing to netCDF didn't work previously and all other scenarios would have been in-memory only or to GeoTiff, which should work with this change.

@mraspaud
