### PR TITLE
docs: fix minor code block issue for local installation in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -78,9 +78,9 @@ Using python::
     $ python -m venv venv
     $ . venv/bin/activate
 
-4. Install your local copy into a virtualenv.
+4. Install your local copy into a virtualenv::
 
-    $ python -m pip install -e .[all]
+    $ python -m pip install -e ".[all]"
     $ python -m pip install -r requirements/dev.txt
 
 5. Setup pre-commit hooks::


### PR DESCRIPTION
Fixes a typo which caused code block rendering to fail. Also adds quotes around `.[all]` as `pip install -e .[all]` fails in some environments. E.g.:
```console
$ python -m pip install -e .[all]
zsh: no matches found: .[all]

$ python -m pip install -e ".[all]"
... # (works)
```

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

:point_up: I didn't add anything to `docs/history.rst` as it doesn't appear to be the convention when updating documentation.
