### PR TITLE
MNT: recommend write_crs & deprecate set_crs

### DIFF
--- a/docs/getting_started/crs_management.ipynb
+++ b/docs/getting_started/crs_management.ipynb
@@ -527,7 +527,9 @@
     "This modifies the `xarray.Dataset` or `xarray.DataArray` and sets the CRS in a CF compliant manner.\n",
     "\n",
     "- [rio.write_crs()](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.write_crs)\n",
-    "- [rio.crs](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.crs)"
+    "- [rio.crs](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.crs)\n",
+    "\n",
+    "**Note:** It is generally recommended to use `rio.write_crs()` over `rio.set_crs()` if you want the CRS to persist on the Dataset/DataArray. Writing a Dataset/DataArray after calling only `rio.set_crs()` will not write the CRS information in a CF compliant manner."
    ]
   },
   {
@@ -1098,7 +1100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/docs/getting_started/crs_management.ipynb
+++ b/docs/getting_started/crs_management.ipynb
@@ -529,7 +529,7 @@
     "- [rio.write_crs()](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.write_crs)\n",
     "- [rio.crs](../rioxarray.rst#rioxarray.rioxarray.XRasterBase.crs)\n",
     "\n",
-    "**Note:** It is generally recommended to use `rio.write_crs()` over `rio.set_crs()` if you want the CRS to persist on the Dataset/DataArray. Writing a Dataset/DataArray after calling only `rio.set_crs()` will not write the CRS information in a CF compliant manner."
+    "**Note:** It is recommended to use `rio.write_crs()` if you want the CRS to persist on the Dataset/DataArray and to write the CRS CF compliant metadata. Calling only `rio.set_crs()` CRS storage method is lossy and will not modify the Dataset/DataArray metadata."
    ]
   },
   {

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -361,7 +361,8 @@ class XRasterBase:
         Set the CRS value for the Dataset/DataArray without modifying
         the dataset/data array.
 
-        DeprecationWarning: It is recommended to use `rio.write_crs()` instead. This
+        .. deprecated:: 0.15.8
+            It is recommended to use `rio.write_crs()` instead. This
         method will likely be removed in a future release.
 
         Parameters

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -374,7 +374,7 @@ class XRasterBase:
 
         Returns
         -------
-        :obj:`xarray.Dataset` | :obj:`xarray.DataArray`
+        :obj:`xarray.Dataset` | :obj:`xarray.DataArray`:
             Dataset with crs attribute.
         """
         warnings.warn(
@@ -402,7 +402,7 @@ class XRasterBase:
 
         Returns
         -------
-        :obj:`xarray.Dataset` | :obj:`xarray.DataArray`:
+        xarray.Dataset | xarray.DataArray
             Dataset with crs attribute.
         """
         crs = crs_from_user_input(input_crs)

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -380,7 +380,7 @@ class XRasterBase:
         warnings.warn(
             "It is recommended to use `rio.write_crs()` instead. `rio.set_crs() will likely"
             "be removed in a future release.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -306,7 +306,7 @@ class XRasterBase:
         # pyproj CRS if possible for performance
         for crs_attr in ("spatial_ref", "crs_wkt"):
             try:
-                self.set_crs(
+                self._set_crs(
                     self._obj.coords[self.grid_mapping].attrs[crs_attr],
                     inplace=True,
                 )
@@ -316,14 +316,14 @@ class XRasterBase:
 
         # look in grid_mapping
         try:
-            self.set_crs(
+            self._set_crs(
                 pyproj.CRS.from_cf(self._obj.coords[self.grid_mapping].attrs),
                 inplace=True,
             )
         except (KeyError, pyproj.exceptions.CRSError):
             try:
                 # look in attrs for 'crs'
-                self.set_crs(self._obj.attrs["crs"], inplace=True)
+                self._set_crs(self._obj.attrs["crs"], inplace=True)
             except KeyError:
                 self._crs = False
                 return None
@@ -374,7 +374,7 @@ class XRasterBase:
 
         Returns
         -------
-        :obj:`xarray.Dataset` | :obj:`xarray.DataArray`:
+        :obj:`xarray.Dataset` | :obj:`xarray.DataArray`
             Dataset with crs attribute.
         """
         warnings.warn(
@@ -384,6 +384,27 @@ class XRasterBase:
             stacklevel=2,
         )
 
+        return self._set_crs(input_crs, inplace=inplace)
+
+    def _set_crs(
+        self, input_crs: Any, inplace: bool = True
+    ) -> Union[xarray.Dataset, xarray.DataArray]:
+        """
+        Set the CRS value for the Dataset/DataArray without modifying
+        the dataset/data array.
+
+        Parameters
+        ----------
+        input_crs: object
+            Anything accepted by `rasterio.crs.CRS.from_user_input`.
+        inplace: bool, optional
+            If True, it will write to the existing dataset. Default is False.
+
+        Returns
+        -------
+        :obj:`xarray.Dataset` | :obj:`xarray.DataArray`:
+            Dataset with crs attribute.
+        """
         crs = crs_from_user_input(input_crs)
         obj = self._get_obj(inplace=inplace)
         obj.rio._crs = crs
@@ -495,7 +516,7 @@ class XRasterBase:
         >>> raster = raster.rio.write_crs("epsg:4326")
         """
         if input_crs is not None:
-            data_obj = self.set_crs(input_crs, inplace=inplace)
+            data_obj = self._set_crs(input_crs, inplace=inplace)
         else:
             data_obj = self._get_obj(inplace=inplace)
 

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -378,7 +378,7 @@ class XRasterBase:
             Dataset with crs attribute.
         """
         warnings.warn(
-            "It is recommended to use `rio.write_crs()` instead. `rio.set_crs() will likely"
+            "It is recommended to use 'rio.write_crs()' instead. 'rio.set_crs()' will likely"
             "be removed in a future release.",
             FutureWarning,
             stacklevel=2,

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -2,6 +2,7 @@
 This module is an extension for xarray to provide rasterio capabilities
 to xarray datasets/dataarrays.
 """
+
 # pylint: disable=too-many-lines
 import json
 import math
@@ -375,6 +376,13 @@ class XRasterBase:
         :obj:`xarray.Dataset` | :obj:`xarray.DataArray`:
             Dataset with crs attribute.
         """
+        warnings.warn(
+            "It is recommended to use `rio.write_crs()` instead. `rio.set_crs() will likely"
+            "be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         crs = crs_from_user_input(input_crs)
         obj = self._get_obj(inplace=inplace)
         obj.rio._crs = crs

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -360,6 +360,9 @@ class XRasterBase:
         Set the CRS value for the Dataset/DataArray without modifying
         the dataset/data array.
 
+        DeprecationWarning: It is recommended to use `rio.write_crs()` instead. This
+        method will likely be removed in a future release.
+
         Parameters
         ----------
         input_crs: object


### PR DESCRIPTION
There is some confusion around when to use `write_crs` versus `set_crs`. This adds a small note to generally prefer write_crs when CRS persistence is needed. Fixes #743

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #743 
 - [ ] Resolves all uncertainty around the initial issue(s)

One remaining nit that I would like to clarify in the documentation as well: when exactly _should_ people use `rio.set_crs()` and not `rio.write_crs()`? 
