### PR TITLE
ENH: Add allow_one_dimensional_raster option to rio.clip_box

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,8 +1,9 @@
 History
 =======
 
-Latest
+0.16.0
 ------
+- ENH: Add `allow_one_dimensional_raster` option to `rio.clip_box` (issue #708)
 
 0.15.7
 ------

--- a/rioxarray/raster_array.py
+++ b/rioxarray/raster_array.py
@@ -713,10 +713,12 @@ class RasterArray(XRasterBase):
         auto_expand: Union[bool, int] = False,
         auto_expand_limit: int = 3,
         crs: Optional[Any] = None,
+        allow_one_dimensional_raster: bool = False,
     ) -> xarray.DataArray:
         """Clip the :obj:`xarray.DataArray` by a bounding box.
 
         .. versionadded:: 0.12 crs
+        .. versionadded:: 0.16 allow_one_dimensional_raster
 
         Parameters
         ----------
@@ -736,16 +738,19 @@ class RasterArray(XRasterBase):
         crs: :obj:`rasterio.crs.CRS`, optional
             The CRS of the bounding box. Default is to assume it is the same
             as the dataset.
+        allow_one_dimensional_raster: bool, optional
+            If True, allow clipping to/from a one dimensional raster.
 
         Returns
         -------
         xarray.DataArray:
             The clipped object.
         """
-        if self.width == 1 or self.height == 1:
+        if not allow_one_dimensional_raster and (self.width == 1 or self.height == 1):
             raise OneDimensionalRaster(
                 "At least one of the raster x,y coordinates has only one point."
-                f"{_get_data_var_message(self._obj)}"
+                f"{_get_data_var_message(self._obj)}. "
+                "Set allow_one_dimensional_raster=True to disable this error."
             )
 
         if crs is not None and self.crs is None:
@@ -819,11 +824,14 @@ class RasterArray(XRasterBase):
                 raise NoDataInBounds(
                     f"No data found in bounds.{_get_data_var_message(self._obj)}"
                 )
-            if cl_array.rio.width == 1 or cl_array.rio.height == 1:
+            if not allow_one_dimensional_raster and (
+                cl_array.rio.width == 1 or cl_array.rio.height == 1
+            ):
                 raise OneDimensionalRaster(
                     "At least one of the clipped raster x,y coordinates"
                     " has only one point."
-                    f"{_get_data_var_message(self._obj)}"
+                    f"{_get_data_var_message(self._obj)}. "
+                    "Set allow_one_dimensional_raster=True to disable this error."
                 )
 
         # make sure correct attributes preserved & projection added

--- a/rioxarray/raster_dataset.py
+++ b/rioxarray/raster_dataset.py
@@ -256,12 +256,14 @@ class RasterDataset(XRasterBase):
         auto_expand: Union[bool, int] = False,
         auto_expand_limit: int = 3,
         crs: Optional[Any] = None,
+        allow_one_dimensional_raster: bool = False,
     ) -> xarray.Dataset:
         """Clip the :class:`xarray.Dataset` by a bounding box in dimensions 'x'/'y'.
 
         .. warning:: Clips variables that have dimensions 'x'/'y'. Others are appended as is.
 
         .. versionadded:: 0.12 crs
+        .. versionadded:: 0.16 allow_one_dimensional_raster
 
         Parameters
         ----------
@@ -281,6 +283,8 @@ class RasterDataset(XRasterBase):
         crs: :obj:`rasterio.crs.CRS`, optional
             The CRS of the bounding box. Default is to assume it is the same
             as the dataset.
+        allow_one_dimensional_raster: bool, optional
+            If True, allow clipping to/from a one dimensional raster.
 
         Returns
         -------
@@ -302,6 +306,7 @@ class RasterDataset(XRasterBase):
                         auto_expand=auto_expand,
                         auto_expand_limit=auto_expand_limit,
                         crs=crs,
+                        allow_one_dimensional_raster=allow_one_dimensional_raster,
                     )
                 )
             except MissingSpatialDimensionError:

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -418,6 +418,27 @@ def test_clip_box__one_dimension_error(modis_clip):
             )
 
 
+def test_clip_box__one_dimension_error__allowed(modis_clip):
+    with modis_clip["open"](modis_clip["input"]) as xdi:
+        # test after raster clipped
+        assert xdi.rio.clip_box(
+            minx=-7272735.53951584,  # xdi.x[5].values
+            miny=5048834.500182299,  # xdi.y[5].values
+            maxx=-7272735.53951584,  # xdi.x[5].values
+            maxy=5048834.500182299,  # xdi.y[5].values
+            allow_one_dimensional_raster=True,
+        ).rio.shape == (1, 1)
+        # test before raster clipped
+        if not isinstance(modis_clip["open"], partial):
+            assert xdi.isel(x=slice(5, 6), y=slice(5, 6)).rio.clip_box(
+                minx=-7272735.53951584,  # xdi.x[5].values
+                miny=5048371.187465771,  # xdi.y[7].values
+                maxx=-7272272.226799311,  # xdi.x[7].values
+                maxy=5048834.500182299,  # xdi.y[5].values
+                allow_one_dimensional_raster=True,
+            ).rio.shape == (1, 1)
+
+
 def test_clip_box__nodata_in_bounds():
     with rioxarray.open_rasterio(
         os.path.join(TEST_INPUT_DATA_DIR, "clip_bbox__out_of_bounds.tif")


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #708 
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
