### PR TITLE
DOC: Clearer docstring for `open_rasterio`

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -1015,8 +1015,8 @@ def open_rasterio(
     """Open a file with rasterio (experimental).
 
     This should work with any file that rasterio can open (most often:
-    geoTIFF). The x and y coordinates are generated from the file's 
-    geoinformation and refer to the center of the pixel.
+    geoTIFF). The x and y coordinates are generated automatically from the 
+    file's geoinformation and refer to the center of the pixel.
     
     .. versionadded:: 0.13 band_as_variable
 

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -1015,12 +1015,9 @@ def open_rasterio(
     """Open a file with rasterio (experimental).
 
     This should work with any file that rasterio can open (most often:
-    geoTIFF). The x and y coordinates are generated automatically from the
-    file's geoinformation, shifted to the center of each pixel (see
-    `"PixelIsArea" Raster Space
-    <http://web.archive.org/web/20160326194152/http://remotesensing.org/geotiff/spec/geotiff2.5.html#2.5.2>`_
-    for more information).
-
+    geoTIFF). The x and y coordinates are generated from the file's 
+    geoinformation and refer to the center of the pixel.
+    
     .. versionadded:: 0.13 band_as_variable
 
     Parameters

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -1015,9 +1015,9 @@ def open_rasterio(
     """Open a file with rasterio (experimental).
 
     This should work with any file that rasterio can open (most often:
-    geoTIFF). The x and y coordinates are generated automatically from the 
+    geoTIFF). The x and y coordinates are generated automatically from the
     file's geoinformation and refer to the center of the pixel.
-    
+
     .. versionadded:: 0.13 band_as_variable
 
     Parameters


### PR DESCRIPTION
Docstring states what the dataset's coordinates refer to without adding unnecessary detail

See https://github.com/corteva/rioxarray/issues/805 for discussion, in particular https://github.com/corteva/rioxarray/issues/805#issuecomment-2393099260

 - [x] Closes #805
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
