### PR TITLE
BUG: Fix chunk arguments for normalize_chunks

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -929,7 +929,7 @@ def _prepare_dask(
             chunks=(1, "auto", "auto"),
             shape=(riods.count, riods.height, riods.width),
             dtype=_rasterio_to_numpy_dtype(riods.dtypes),
-            previous_chunks=tuple(c for c in block_shape),
+            previous_chunks=block_shape,
         )
     token_filename = filename
     if bidx is not None:

--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -929,7 +929,7 @@ def _prepare_dask(
             chunks=(1, "auto", "auto"),
             shape=(riods.count, riods.height, riods.width),
             dtype=_rasterio_to_numpy_dtype(riods.dtypes),
-            previous_chunks=tuple((c,) for c in block_shape),
+            previous_chunks=tuple(c for c in block_shape),
         )
     token_filename = filename
     if bidx is not None:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API

The current specification of the previous chunks is incorrect, it always needs to sum up to the whole axis if given as tuples. What you want is an integer here.

I've recently refactored how normalize_chunks works and this will break things for you. I'll add some compat code for now, but will want to remove this at some point, so fixing it over here 