### PR TITLE
BUG: Fix reproject with geoloc arrays not named xc|yc

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,7 @@ History
 
 Latest
 ------
-
+- BUG: Fix reproject with geoloc arrays not named xc|yc (#840)
 
 0.18.1
 -------

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -143,9 +143,13 @@ def _get_nonspatial_coords(
         src_data_array.rio.x_dim,
         src_data_array.rio.y_dim,
         DEFAULT_GRID_MAP,
-        "xc",
-        "yc",
     }:
+        # skip 2D spatial coords
+        if (
+            src_data_array.rio.x_dim in src_data_array[coord].dims
+            and src_data_array.rio.y_dim in src_data_array[coord].dims
+        ):
+            continue
         if src_data_array[coord].ndim == 1:
             coords[coord] = xarray.IndexVariable(
                 src_data_array[coord].dims,


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #840
 - [x] Tests added
 - [x] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
