### PR TITLE
DEP: Support Python 3.12-3.14

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -28,7 +28,7 @@ jobs:
           init-shell: bash
           environment-name: docs
           create-args: >-
-            python=3.10
+            python=3.12
             rasterio
             xarray
             scipy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - uses: pre-commit/action@v3.0.1
 
   docker_tests:
@@ -34,20 +34,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
         rasterio-version: ['']
         xarray-version: ['']
         numpy-version: ['']
         run-with-scipy: ['YES']
-        gdal-version: ['3.10.0']
+        gdal-version: ['3.10.3']
         include:
-          - python-version: '3.10'
+          - python-version: '3.12'
             rasterio-version: ''
             xarray-version: '==2024.7.0'
             numpy-version: '<2'
             run-with-scipy: 'YES'
             gdal-version: '3.8.2'
-          - python-version: '3.10'
+          - python-version: '3.12'
             rasterio-version: ''
             xarray-version: ''
             numpy-version: ''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.10
+    python: python3.12
 
 repos:
     -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -136,7 +136,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.10-3.12.
+3. The pull request should work for Python 3.12-3.14.
 
 Tips
 ----

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 
 environment:
   matrix:
-    - PYTHON_VERSION: "3.10"
+    - PYTHON_VERSION: "3.12"
       MINICONDA: "C:\\Miniconda3-x64"
 
 install:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@ History
 
 Latest
 ------
+- DEP: Support Python 3.12-3.14
 - ENH: Enable string resample parameter in rio.reproject and rio.reproject_match (#870)
 
 0.19.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.10
+python_version = 3.12
 
 [mypy-affine]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,14 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: GIS",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "packaging",
     "rasterio>=1.4.3",


### PR DESCRIPTION
Python 3.11 is no longer supported in the scientific python ecosystem: https://scientific-python.org/specs/spec-0000/