### PR TITLE
Convert tuple chunks to dict in `_prepare_dask` to avoid DeprecationWarning

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -931,8 +931,6 @@ def _prepare_dask(
             dtype=_rasterio_to_numpy_dtype(riods.dtypes),
             previous_chunks=block_shape,
         )
-
-    if isinstance(chunks, tuple):
         # xarray wants chunks as a dict rather than a tuple
         chunks = dict(zip(result.dims, chunks, strict=True))
 

--- a/test/integration/test_integration__io.py
+++ b/test/integration/test_integration__io.py
@@ -754,8 +754,8 @@ def test_chunks():
 
 
 @pytest.mark.filterwarnings("error::DeprecationWarning")
-@pytest.mark.parametrize("chunks", [True, (1, 100, 100)])
-def test_chunks_as_tuple_no_deprecation_warning(chunks):
+@pytest.mark.parametrize("chunks", [True, "auto"])
+def test_auto_chunks_no_deprecation_warning(chunks):
     with rioxarray.open_rasterio(
         os.path.join(TEST_INPUT_DATA_DIR, "cog.tif"), chunks=chunks
     ) as rds:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #878 
 - [x] Tests added

Providing chunks as tuples to `open_rasterio` is still allowed (and doesn't generate a warning) so the interface remains the same. However in `_prepare_dask` any chunks provided as tuples are converted to a dict, assuming the dimension ordering in the provided tuple is (band, y, x) (the same as the returned dataarray). If the tuple is not of length 3 an error is raised.

This should remove the DeprecationWarning by xarray when passing chunks=True, chunks="auto" or chunks as a tuple.