### PR TITLE
LNT: Ignore mypy error

### DIFF
--- a/rioxarray/_io.py
+++ b/rioxarray/_io.py
@@ -932,7 +932,7 @@ def _prepare_dask(
             previous_chunks=block_shape,
         )
         # xarray wants chunks as a dict rather than a tuple
-        chunks = dict(zip(result.dims, chunks, strict=True))
+        chunks = dict(zip(result.dims, chunks, strict=True))  # type: ignore[arg-type]
 
     token_filename = filename
     if bidx is not None:


### PR DESCRIPTION
https://github.com/corteva/rioxarray/actions/runs/20248468979/job/58134585937

```
rioxarray/_io.py:935: error: Argument 2 to "zip" has incompatible type "int | tuple[Any, ...] | dict[Any, Any]"; expected "Iterable[Any]"  [arg-type]
```