### PR TITLE
Align conda Python version with pre-commit's

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ name: rioxarray
 channels:
 - conda-forge
 dependencies:
-- python
+- python=3.12  # To align with pre-commit requirements
 - rasterio
 - libgdal-netcdf
 - libgdal-hdf4


### PR DESCRIPTION
Quick PR to specify the Python version to the conda env.

Otherwise, following CONTRIBUTING guideline fails at the pre-commit step, because default python version is 3.14 in the conda env previously installed and pre-commit specifically asks for 3.12.

Feel free to discard this is if it's not relevant.