### PR TITLE
DOC: Add missing ipython docs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 doc = [
     "sphinx-click",
     "nbsphinx",
+    "ipython",
     "sphinx_rtd_theme",
 ]
 test = [


### PR DESCRIPTION
This shows up 10s or 100s of times in the docs build job:

```
 /home/runner/work/rioxarray/rioxarray/docs/getting_started/nodata_management.ipynb:: WARNING: Pygments lexer name 'ipython3' is not known [misc.highlighting_failure]
```

Judging by https://github.com/spatialaudio/nbsphinx/issues/24 this is just a missing ipython dependency and I was able to reproduce it locally.

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Fully documented, including `docs/history.rst` for all changes and `docs/rioxarray.rst` for new API
