### PR TITLE
MNT: several updates to pyproject.toml, ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ celerybeat-schedule
 # dotenv
 .env
 
+# uv env
+uv.lock
+
 # virtualenv
 .venv
 venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ keywords = [
     "rasterio",
 ]
 readme = "README.rst"
-license = {text = "Apache"}
+license = "Apache-2.0"
+license-files = ["LICENSE*", "AUTHORS.rst"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Natural Language :: English",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: GIS",
     "Programming Language :: Python",
@@ -78,7 +78,7 @@ changelog = "https://corteva.github.io/rioxarray/stable/history.html"
 [tool.setuptools.packages.find]
 include = ["rioxarray", "rioxarray.*"]
 
-[options.package_data]
+[tool.setuptools.package-data]
 rioxarray = [
   "py.typed",
 ]
@@ -93,6 +93,3 @@ interp = [
 all = [
     "scipy"
 ]
-
-[tool.black]
-target_version = ["py310"]


### PR DESCRIPTION
Apologies for cobbling a few fixes into one PR.


These changes are related to [PEP 639](https://peps.python.org/pep-0639/), and clear up deprecation warnings when building:
- Change `[project.license]` from a table to a SPDX license expression
- Add `[project.license-files]`
- Remove the license from the classifiers
- Correction `[options.package_data]` -> `[tool.setuptools.package-data]`

Other changes:
- Remove `[tool.black]`, because `target_version` was incorrect (should be `target-version`), but more importantly this was tracking an old version of Python, and by default, Black will infer target versions from the project metadata ([docs](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version))
- Ignore `uv.lock` files, which are created with ([e.g.](https://docs.astral.sh/uv/concepts/projects/sync/)) `uv sync --all-extras`