### PR TITLE
BUG: Fix rio.bounds() for rotation / asymmetric shear in the transform (#847)

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,7 @@ History
 Unreleased
 ----------
 - ENH: Add write support for Zarr spatial and proj conventions
+- BUG: Fix `rio.bounds()` for grids with rotation or asymmetric shear in the transform (#847)
 
 0.22.0
 ------

--- a/rioxarray/_spatial_utils.py
+++ b/rioxarray/_spatial_utils.py
@@ -58,7 +58,7 @@ def _affine_has_rotation(affine: Affine) -> bool:
     -------
     bool
     """
-    return affine.b == affine.d != 0
+    return affine.b != 0 or affine.d != 0
 
 
 def _resolution(affine: Affine) -> tuple[float, float]:
@@ -87,6 +87,41 @@ def _resolution(affine: Affine) -> tuple[float, float]:
         math.sqrt(affine.a**2 + affine.d**2),
         math.sqrt(affine.b**2 + affine.e**2),
     )
+
+
+def _rotated_bounds(
+    affine: Affine, *, width: int, height: int
+) -> tuple[float, float, float, float]:
+    """
+    Compute the axis-aligned bounds of a grid whose affine has rotation/shear.
+
+    The bounds are the envelope of the four corners of the grid transformed
+    by the affine. This matches how :obj:`rasterio.io.DatasetReader.bounds`
+    handles a non-north-up transform.
+
+    Parameters
+    ----------
+    affine: :obj:`affine.Affine`
+        The affine of the grid.
+    width: int
+        The width of the grid.
+    height: int
+        The height of the grid.
+
+    Returns
+    -------
+    left, bottom, right, top: float
+        Outermost coordinates of the grid.
+    """
+    corners = (
+        affine * (0, 0),
+        affine * (width, 0),
+        affine * (0, height),
+        affine * (width, height),
+    )
+    x_coords = [corner[0] for corner in corners]
+    y_coords = [corner[1] for corner in corners]
+    return min(x_coords), min(y_coords), max(x_coords), max(y_coords)
 
 
 def affine_to_coords(

--- a/rioxarray/rioxarray.py
+++ b/rioxarray/rioxarray.py
@@ -36,6 +36,7 @@ from rioxarray._spatial_utils import (  # noqa: F401, pylint: disable=unused-imp
     _has_spatial_dims,
     _order_bounds,
     _resolution,
+    _rotated_bounds,
     affine_to_coords,
 )
 from rioxarray.crs import crs_from_user_input
@@ -840,6 +841,11 @@ class XRasterBase:
         left, bottom, right, top: float
             Outermost coordinates of the `xarray.DataArray` | `xarray.Dataset`.
         """
+        transform = self._cached_transform()
+        if transform is not None and _affine_has_rotation(transform):
+            # a rotated/sheared grid is not axis-aligned, so the bounds are
+            # the envelope of the four (transformed) corners of the grid.
+            return _rotated_bounds(transform, width=self.width, height=self.height)
         minx, miny, maxx, maxy = self._unordered_bounds(recalc=recalc)
         resolution_x, resolution_y = self.resolution(recalc=recalc)
         return _order_bounds(

--- a/test/integration/test_integration_rioxarray.py
+++ b/test/integration/test_integration_rioxarray.py
@@ -21,7 +21,11 @@ from rasterio.crs import CRS
 from rasterio.windows import Window
 
 import rioxarray
-from rioxarray._spatial_utils import _generate_spatial_coords, _make_coords
+from rioxarray._spatial_utils import (
+    _affine_has_rotation,
+    _generate_spatial_coords,
+    _make_coords,
+)
 from rioxarray.exceptions import (
     DimensionMissingCoordinateError,
     MissingCRS,
@@ -3311,6 +3315,58 @@ def test_bounds__ordered__dataarray():
 def test_bounds__ordered__dataset():
     xds = xarray.Dataset(None, coords={"x": range(5), "y": range(5)})
     assert xds.rio.bounds() == (-0.5, -0.5, 4.5, 4.5)
+
+
+@pytest.mark.parametrize(
+    "affine",
+    [
+        Affine(1, 0.3, 0, 0.1, -1, 0),  # asymmetric shear (b != d), see gh #847
+        Affine(1, 0.3, 0, 0.3, -1, 0),  # symmetric shear (b == d)
+        Affine(1, 0.2, 0, 0, -1, 0),  # single off-diagonal
+    ],
+)
+def test_bounds__rotated(affine):
+    # https://github.com/corteva/rioxarray/issues/847
+    # a sheared/rotated affine (b or d nonzero) is detected as having rotation ...
+    assert _affine_has_rotation(affine)
+    width, height = 4, 5
+    image = numpy.zeros((height, width), dtype="uint8")
+    xds = (
+        xarray.DataArray(
+            image,
+            dims=("y", "x"),
+            coords=_generate_spatial_coords(affine=affine, width=width, height=height),
+        )
+        .rio.write_crs("EPSG:4326", inplace=True)
+        .rio.write_transform(affine, inplace=True)
+        .rio.write_coordinate_system(inplace=True)
+    )
+    # ... and the bounds are the axis-aligned envelope of the 4 corners
+    corners = [
+        affine * (0, 0),
+        affine * (width, 0),
+        affine * (0, height),
+        affine * (width, height),
+    ]
+    xs = [corner[0] for corner in corners]
+    ys = [corner[1] for corner in corners]
+    expected = (min(xs), min(ys), max(xs), max(ys))
+    assert_almost_equal(xds.rio.bounds(), expected)
+    # cross-check against rasterio's own bounds for the same transform
+    with rasterio.io.MemoryFile() as memfile:
+        with memfile.open(
+            driver="GTiff",
+            height=height,
+            width=width,
+            count=1,
+            dtype="uint8",
+            crs="EPSG:4326",
+            transform=affine,
+        ) as dataset:
+            dataset.write(image, 1)
+        with memfile.open() as dataset:
+            rasterio_bounds = dataset.bounds
+    assert_almost_equal(xds.rio.bounds(), tuple(rasterio_bounds))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #847

## Why

`rioxarray/_spatial_utils.py::_affine_has_rotation` returned:

```python
return affine.b == affine.d != 0
```

That only detects **symmetric** shear (`b == d`). For an **asymmetric**
shear/rotation (`b != d`, either nonzero) it returns `False`, so the grid is
treated as north-up: `_resolution` returns `(a, e)` and `rio.bounds()` ignores the
shear entirely.

While confirming the bug I found the problem is actually broader than detection.
`bounds()` never computes an axis-aligned envelope for a rotated grid — it pads the
coordinate/origin extent by the (sign-lost) resolution. So even the
**symmetric**-shear case (where `_affine_has_rotation` already returned `True`)
produced wrong bounds. Both paths were incorrect; only the symptom differed.

Reproduce (`w=4, h=5`):

| transform | `rio.bounds()` (before) | rasterio `.bounds` / 4-corner envelope (correct) |
|---|---|---|
| `Affine(1, 0.3, 0, 0.1, -1, 0)` asymmetric | `(0, -5, 4, 0)` | `(0, -5, 5.5, 0.4)` |
| `Affine(1, 0.3, 0, 0.3, -1, 0)` symmetric | `(0, 0, 4.18, 5.22)` | `(0, -5, 5.5, 1.2)` |
| `Affine(1, 0.2, 0, 0, -1, 0)` single off-diagonal | `(0, -5, 4, 0)` | `(0, -5, 5, 0)` |

(Patching only `_affine_has_rotation` changes the asymmetric result to
`(0, 0, 4.02, 5.22)` — still wrong, now matching the broken symmetric path.)

## What

- Widen `_affine_has_rotation` to `affine.b != 0 or affine.d != 0` (rotation or
  shear, symmetric or not). This mirrors rasterio's own `not (b == d == 0)` test in
  `DatasetReader.bounds`.
- Add `_rotated_bounds(affine, *, width, height)` returning the axis-aligned
  envelope of the four transformed grid corners
  `affine * {(0,0),(w,0),(0,h),(w,h)}` → `(min x, min y, max x, max y)`.
- `bounds()` uses that envelope when the (cached) transform has rotation; the
  north-up fast path is untouched.

### Geometry reasoning

For a north-up transform the outer extent is just the opposite corners, so the
existing resolution-based path is fine. Under rotation/shear the grid is no longer
axis-aligned, so the *outermost coordinates* are the envelope of all four corners —
exactly what `rasterio.io.DatasetReader.bounds` returns for a non-north-up
transform. Corners are computed from the pixel-*corner* transform (as written to the
GeoTransform), so the result is edge (not center) bounds, consistent with the
north-up path. Verified equal to rasterio's `DatasetReader.bounds` to <1e-9 for
asymmetric, symmetric, single-off-diagonal, and north-up transforms.

### Side effect on `resolution()` (deliberate)

Widening `_affine_has_rotation` also routes `resolution()` for **asymmetric /
single-off-diagonal** grids through the rotated branch, so it now returns magnitudes
`(sqrt(a²+d²), sqrt(b²+e²))` instead of `(a, e)`. This is intentional and brings
those (rare) grids in line with rasterio's `res` convention; for symmetric shear
this was already the behavior. No test encoded the old `(a, e)` value.

## Tests

- New parametrized `test_bounds__rotated` (asymmetric shear, symmetric shear, single
  off-diagonal): asserts `_affine_has_rotation` is `True` and that `rio.bounds()`
  equals both the 4-corner envelope and rasterio's own `DatasetReader.bounds`. Fails
  before, passes after.
- Existing bounds / resolution / rotation / transform / `reproject_match` tests in
  `test_integration_rioxarray.py` still pass (58 passed). No existing expected values
  changed (the previously-broken symmetric-shear bounds were not asserted anywhere).

## Note re: upstream

There is a parallel discussion about rasterio (rasterio#2586). Per @snowman2's
guidance on #847, this is fixed **in rioxarray** — @lantson confirmed rasterio
already computes these bounds correctly (`DatasetReader.bounds`), and this PR brings
`rio.bounds()` in line with it. No upstream change is required.
